### PR TITLE
Initial commit pipeline interface

### DIFF
--- a/trailblazer/exc.py
+++ b/trailblazer/exc.py
@@ -11,7 +11,7 @@ class MissingFileError(TrailblazerError):
     pass
 
 
-class MipStartError(TrailblazerError):
+class PipelineStartError(TrailblazerError):
     pass
 
 

--- a/trailblazer/mip/start.py
+++ b/trailblazer/mip/start.py
@@ -3,7 +3,8 @@ import logging
 import signal
 import subprocess
 
-from trailblazer.exc import MipStartError
+from trailblazer.exc import PipelineStartError
+from trailblazer.pipeline import Pipeline
 
 LOG = logging.getLogger(__name__)
 
@@ -27,23 +28,9 @@ CLI_OPTIONS = {
 }
 
 
-class MipCli(object):
+class MipCli(Pipeline):
 
     """Wrapper around MIP command line interface."""
-
-    def __init__(self, script):
-        """Initialize MIP command line interface."""
-        self.script = script
-
-    def __call__(self, config, family, **kwargs):
-        """Execute the pipeline."""
-        command = self.build_command(config, family=family, **kwargs)
-        LOG.debug(' '.join(command))
-        process = self.execute(command)
-        process.wait()
-        if process.returncode != 0:
-            raise MipStartError('error starting analysis, check the output')
-        return process
 
     def build_command(self, config, **kwargs):
         """Builds the command to execute MIP."""
@@ -58,12 +45,3 @@ class MipCli(object):
                     command.append(value)
         return command
 
-
-
-    def execute(self, command):
-        """Start a new MIP run."""
-        process = subprocess.Popen(
-            command,
-            preexec_fn=lambda: signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-        )
-        return process

--- a/trailblazer/pipeline/__init__.py
+++ b/trailblazer/pipeline/__init__.py
@@ -1,0 +1,1 @@
+from .pipeline import Pipeline

--- a/trailblazer/pipeline/pipeline.py
+++ b/trailblazer/pipeline/pipeline.py
@@ -1,0 +1,37 @@
+import logging
+import signal
+import subprocess
+
+LOG = logging.getLogger(__name__)
+
+class Pipeline(object):
+
+    def __init__(self, script):
+        """Initialize command line interface."""
+        self.script = script
+
+    def start(self, family, config=None, **kwargs):
+        """Execute the pipeline."""
+        command = self.build_command(config, family=family, **kwargs)
+        LOG.debug(' '.join(command))
+        process = self.execute(command)
+        process.wait()
+        if process.returncode != 0:
+            raise PipelineStartError('error starting analysis, check the output')
+        return process
+
+    def build_command(self, **kwargs):
+        """Build the command."""
+        command = [self.script]
+        for key, value in kwargs.items():
+            command.append(key)
+            command.append(value)
+        return command
+
+    def execute(self, command):
+        """Start a new run."""
+        process = subprocess.Popen(
+            command,
+            preexec_fn=lambda: signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+        )
+        return process


### PR DESCRIPTION
This was the initial work we put in beginning of March. To summarize: it makes the interface for starting a pipeline more generic instead of having it MIP specific. It also defines the interface or provides a template on how to define the options for a pipeline.

This code is untested and requires unit tests and a manual check that it would actually work.

Feel free to improve, work on top of this, or comment.