### PR TITLE
Add python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 matrix:
   include:
     - language: node_js
@@ -16,6 +17,7 @@ matrix:
     - language: python
       python:
         - '3.6'
+        - '3.7'
       cache: pip
 
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,22 @@ matrix:
     - language: python
       python:
         - '3.6'
+      cache: pip
+
+      before_install:
+        - pip install git-lint pylint pycodestyle yamllint docutils html-linter
+        - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
+
+      install:
+        - pip install -q -r requirements-dev.txt .
+
+      script:
+        - coverage run --source "$(basename "$PWD")" setup.py test
+        - pip check
+
+      after_success: coveralls
+    - language: python
+      python:
         - '3.7'
       cache: pip
 
@@ -32,6 +48,7 @@ matrix:
         - pip check
 
       after_success: coveralls
+
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,9 @@ matrix:
         - pip install -q -r requirements-dev.txt .
 
       script:
-        - coverage run --source "$(basename "$PWD")" setup.py test
+        - py.test -v tests/*
         - pip check
 
-      after_success: coveralls
     - language: python
       python:
         - '3.7'


### PR DESCRIPTION
Add python 3.7 to travis

**How to test**:
1. Nothing much: if travis is testing python 3.6 and 3.7 and it passes , we're in the clear!

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @octocat
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because there is no new functionality.
