### PR TITLE
change obsoleted qccollect key

### DIFF
--- a/tests/fixtures/case/case_qc_sample_info.yaml
+++ b/tests/fixtures/case/case_qc_sample_info.yaml
@@ -83,9 +83,8 @@ recipe:
     path: /path_to/case/case/plink/info/plink_case.0.stdout.txt
   plink_sexcheck:
     path: /path_to/case/case/plink/case_gatkcomb.plink_sexcheck.sexcheck
-  qccollect:
+  qccollect_ar:
     path: /path_to/case/case_qc_metrics.yaml
-  qccollect_ar: {}
   relation_check:
     path: /path_to/case/case/plink/case_gatkcomb.relation_check.mibs
   rhocall_ar:

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -55,10 +55,10 @@ def log_cmd(context, sampleinfo, sacct, quiet, config):
     try:
         new_run = log_analysis(config, sampleinfo=sampleinfo, sacct=sacct)
     except MissingFileError as error:
-        click.echo(click.style(f"Skipping, missing Sacct file: {error.message}", fg='yellow'))
+        click.echo(click.style(f"Skipping, missing Sacct file: {error.message}", fg='red'))
         return
     except KeyError as error:
-        print(click.style(f"unexpected output, missing key: {error.args[0]}", fg='yellow'))
+        print(click.style(f"unexpected output, missing key: {error.args[0]} in {config}", fg='red'))
         return
     if new_run is None:
         if not quiet:

--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -64,7 +64,7 @@ def parse_sampleinfo(data: dict) -> dict:
             'sex_check': (data['recipe']['peddy_ar']['sex_check']['path'] if
                           'peddy_ar' in data['recipe'] else None),
         },
-        'qcmetrics_path': data['recipe']['qccollect']['path'],
+        'qcmetrics_path': data['recipe']['qccollect_ar']['path'],
         'samples': [],
         'snv': {
             'bcf': data['most_complete_bcf']['path'],


### PR DESCRIPTION
This PR fixes the broken trailblazer scan for MIP 7.1 

**How to test**:
1. copy trailblazer database from prod to stage
1. copy vocalgecko case from production to stage
1. install master on stage of the hasta machine: bash servers/resources/hasta.scilifelab.se/update-trailblazer-stage.sh
1. activate stage: `us`
1. run following command: `trailblazer scan | grep qccollect` to show problem that this PR fixes
1. install on stage of the hasta machine: `bash servers/resources/hasta.scilifelab.se/update-trailblazer-stage.sh missing-qccollect`
1. run following command: `trailblazer scan | grep qccollect`

**Expected outcome**:
There should be no matches in the output for qccollect
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it patches a functionality in a backwards compatible manner