### PR TITLE
add option to force

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=3.6   # due to  pytest-cov, pytest-flask
+pytest>=3.6                 # due to  pytest-cov, pytest-flask
 pytest-cov
 pytest-flask
 coveralls
@@ -9,3 +9,4 @@ yamllint
 docutils
 html-linter
 tidy
+six>=1.12                   # due to astroid 2.3.1

--- a/trailblazer/cli/clean.py
+++ b/trailblazer/cli/clean.py
@@ -10,8 +10,9 @@ LOG = logging.getLogger(__name__)
 @click.command()
 @click.option('-y', '--yes', is_flag=True, help='skip manual confirmations')
 @click.option('-d', '--days-ago', default=14, help='days ago analyses were started')
+@click.option('-f', '--force', is_flag=True, help='skip sanity checks')
 @click.pass_context
-def clean(context, days_ago, yes):
+def clean(context, days_ago, yes, force):
     """Clean up files from "old" analyses runs."""
     number_of_days_ago = dt.datetime.now() - dt.timedelta(days=days_ago)
     analyses = context.obj['store'].analyses(
@@ -26,4 +27,4 @@ def clean(context, days_ago, yes):
             print(click.style(f"{analysis_obj.family}: family has been re-started", fg='yellow'))
         else:
             print(f"delete analysis: {analysis_obj.family} ({analysis_obj.id})")
-            context.invoke(delete, analysis_id=analysis_obj.id, yes=yes)
+            context.invoke(delete, analysis_id=analysis_obj.id, yes=yes, force=force)

--- a/trailblazer/cli/delete.py
+++ b/trailblazer/cli/delete.py
@@ -10,7 +10,7 @@ import click
 @click.argument('analysis_id', type=int)
 @click.pass_context
 def delete(context, force, yes, analysis_id):
-    """Delete an analysis log from the database."""
+    """Mark analysis as deleted in db and remove analysis folder on disk."""
     analysis_obj = context.obj['store'].analysis(analysis_id)
     if analysis_obj is None:
         print(click.style('analysis log not found', fg='red'))

--- a/trailblazer/cli/delete.py
+++ b/trailblazer/cli/delete.py
@@ -43,4 +43,5 @@ def delete(context, force, yes, analysis_id):
                 print(click.style(f"analysis deleted: {analysis_obj.family}", fg='blue'))
         else:
             print(click.style(f"analysis output doesn't exist: {analysis_obj.out_dir}", fg='red'))
+            print(click.style("use '--force' to override"))
             context.abort()

--- a/trailblazer/cli/delete.py
+++ b/trailblazer/cli/delete.py
@@ -28,7 +28,7 @@ def delete(context, force, yes, analysis_id):
             print(click.style(f"{analysis_obj.family}: already deleted", fg='red'))
             context.abort()
 
-        if Path(analysis_obj.out_dir).exists():
+        if Path(analysis_obj.out_dir).exists() or force:
             root_dir = context.obj['store'].families_dir
             family_dir = analysis_obj.out_dir
             if not force and (len(family_dir) <= len(root_dir) or root_dir not in family_dir):


### PR DESCRIPTION
This PR adds a fix for trailblazer clean/delete when an analysis has been removed from disk but not trailblazer db

**How to setup:**
1. install on stage of the coffee machine: `bash servers/resources/hasta.scilifelab.se/update-cg-stage.sh THISBRANCH`
1. activate stage: `us`

**How to test delete**:
1. run following command: `trailblazer delete 110257 -f -y`

**Expected outcome**:
- [ ] `tb` should delete the analysis from it's database

**How to test clean**:
1. run following command: `trailblazer clean -f`

**Expected outcome**:
- [x] `tb` should invoke delete with --force set

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [x] tests executed by @patrikgrenfeldt @emiliaol 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because the previous commands should work as before
