### PR TITLE
Show failed last month

### DIFF
--- a/nuxt/pages/stats.vue
+++ b/nuxt/pages/stats.vue
@@ -3,7 +3,7 @@
     <Navbar />
 
     <b-container class="mt-4">
-      <h4 class="mb-3">Top failed job categories</h4>
+      <h4 class="mb-3">Top failed job categories last 31 days</h4>
 
       <b-list-group>
         <b-list-group-item

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -80,15 +80,53 @@ def test_is_running(sample_store, family, expected_bool):
 
 
 def test_aggregate_jobs(sample_store):
+
     # GIVEN a store with some analyses
     assert sample_store.analyses().count() > 0
     all_jobs = sample_store.jobs().count()
     assert all_jobs == 2
+
     # WHEN aggregating data on failed jobs
     jobs_data = sample_store.aggregate_failed()
+
     # THEN it should return a list of dicts per job type with count
     assert isinstance(jobs_data, list)
+
     # ... it should exclude "cancelled" jobs
     assert len(jobs_data) == 1
     assert jobs_data[0]['name'] == 'samtools_mpileup'
     assert jobs_data[0]['count'] == 1
+
+
+def test_aggregate_jobs_since_forever_date(sample_store):
+
+    # GIVEN a store with some analyses
+    assert sample_store.analyses().count() > 0
+    all_jobs = sample_store.jobs().count()
+    assert all_jobs == 2
+    # a date a gazillion days back
+    date_since = datetime.datetime.now() - datetime.timedelta(days=9999)
+
+    # WHEN aggregating data on failed jobs
+    jobs_data = sample_store.aggregate_failed(date_since)
+
+    # THEN it should return a list of dicts per job type with count
+    assert len(jobs_data) == 1
+    assert jobs_data[0]['name'] == 'samtools_mpileup'
+    assert jobs_data[0]['count'] == 1
+
+
+def test_aggregate_jobs_since_yesterday(sample_store):
+
+    # GIVEN a store with some analyses
+    assert sample_store.analyses().count() > 0
+    all_jobs = sample_store.jobs().count()
+    assert all_jobs == 2
+    # a date a gazillion days back
+    date_since = datetime.datetime.now() - datetime.timedelta(days=1)
+
+    # WHEN aggregating data on failed jobs
+    jobs_data = sample_store.aggregate_failed(date_since)
+
+    # THEN it should return a list of dicts per job type with count
+    assert len(jobs_data) == 0

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -75,10 +75,10 @@ def me():
     return jsonify(**g.current_user.to_dict())
 
 
-@blueprint.route('/aggregate/jobs/<int:days_back>', methods=['GET'])
-def aggregate_jobs(days_back: int = 31):
+@blueprint.route('/aggregate/jobs')
+def aggregate_jobs():
     """Return stats about jobs."""
-
+    days_back = int(request.args.get('days_back', 31))
     one_month_ago = datetime.datetime.now() - datetime.timedelta(days=days_back)
 
     data = store.aggregate_failed(one_month_ago)

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 from flask import abort, g, Blueprint, jsonify, make_response, request
 from google.auth import jwt
 
@@ -76,5 +78,8 @@ def me():
 @blueprint.route('/aggregate/jobs')
 def aggregate_jobs():
     """Return stats about jobs."""
-    data = store.aggregate_failed()
+    days_back = int(request.args.get('days_back', 31))
+    one_month_ago = datetime.datetime.now() - datetime.timedelta(days=days_back)
+
+    data = store.aggregate_failed(one_month_ago)
     return jsonify(jobs=data)

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -75,10 +75,10 @@ def me():
     return jsonify(**g.current_user.to_dict())
 
 
-@blueprint.route('/aggregate/jobs')
-def aggregate_jobs():
+@blueprint.route('/aggregate/jobs/<int:days_back>', methods=['GET'])
+def aggregate_jobs(days_back: int = 31):
     """Return stats about jobs."""
-    days_back = int(request.args.get('days_back', 31))
+
     one_month_ago = datetime.datetime.now() - datetime.timedelta(days=days_back)
 
     data = store.aggregate_failed(one_month_ago)


### PR DESCRIPTION
This PR adds functionality to show stats only last 31 days

**How to install**:
1. install on stage of the coffee machine: `bash servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh THISBRANCH`
1. activate stage: `us`

**How to test**:
1. log into tb-stage
1. press stats

**Expected outcome**:
`tb` should shows stats for the last 31 days only.
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @ingkebil 
- [ ] tests executed by @patrikgrenfeldt 
- [ ] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is |minor| **version bump** because it changes functionality in a backwards compatible manner
