### PR TITLE
Mip dna v8.2

### DIFF
--- a/tests/fixtures/case/case_qc_sample_info.yaml
+++ b/tests/fixtures/case/case_qc_sample_info.yaml
@@ -126,6 +126,8 @@ recipe:
       path: /path_to/case/case/varianteffectpredictor/info/varianteffectpredictor_case.1.stderr.txt
   vcfparser_ar:
     path: /path_to/case/case/vcfparser_ar/case_gatkcomb_rhocall_vt_frqf_cadd_vep_parsed.3.vcf
+  version_collect_ar:
+    path: /path_to/case/case/version_collect_ar/case_vcol.yaml
   vt_ar:
     path: /path_to/case/case/vt_ar/info/vt_ar_case.0.0.1.stderr.txt
 sample:
@@ -159,7 +161,7 @@ sample:
         sequence_length: '151'
         sequence_run_type: paired-end
     most_complete_bam:
-      path: /path_to/case/father/gatk_baserecalibration/father_lanes_1_sorted_md_brecal.bam
+      path: /path_to/case/father/gatk_baserecalibration/father_lanes_1_sorted_md_brecal.cram
     mother: '0'
     phenotype: unaffected
     recipe:
@@ -174,6 +176,8 @@ sample:
           log:
             path: /path_to/case/father/chanjo_sexcheck/father_lanes_1_sorted_md_brecal_sex_chanjo_sexcheck.log
           path: /path_to/case/father/chanjo_sexcheck/father_lanes_1_sorted_md_brecal_sex.tsv
+      chromograph_ar:
+          path: /path_to/case/father/chromograph_ar/father_lanes_1234_sorted_md_brecal_tcov_chromograph.tar.gz
       collecthsmetrics:
         father_lanes_1_sorted_md_brecal_collecthsmetrics:
           path: /path_to/case/father/picardtools_collecthsmetrics/father_lanes_1_sorted_md_brecal_collecthsmetrics
@@ -251,7 +255,7 @@ sample:
         sequence_length: '151'
         sequence_run_type: paired-end
     most_complete_bam:
-      path: /path_to/case/child/gatk_baserecalibration/child_lanes_1_sorted_md_brecal.bam
+      path: /path_to/case/child/gatk_baserecalibration/child_lanes_1_sorted_md_brecal.cram
     mother: mother
     phenotype: affected
     recipe:
@@ -266,6 +270,8 @@ sample:
           log:
             path: /path_to/case/child/chanjo_sexcheck/child_lanes_1_sorted_md_brecal_sex_chanjo_sexcheck.log
           path: /path_to/case/child/chanjo_sexcheck/child_lanes_1_sorted_md_brecal_sex.tsv
+      chromograph_ar:
+          path: /path_to/case/child/chromograph_ar/child_lanes_1234_sorted_md_brecal_tcov_chromograph.tar.gz
       collecthsmetrics:
         child_lanes_1_sorted_md_brecal_collecthsmetrics:
           path: /path_to/case/child/picardtools_collecthsmetrics/child_lanes_1_sorted_md_brecal_collecthsmetrics
@@ -343,7 +349,7 @@ sample:
         sequence_length: '151'
         sequence_run_type: paired-end
     most_complete_bam:
-      path: /path_to/case/mother/gatk_baserecalibration/mother_lanes_1_sorted_md_brecal.bam
+      path: /path_to/case/mother/gatk_baserecalibration/mother_lanes_1_sorted_md_brecal.cram
     mother: '0'
     phenotype: unaffected
     recipe:
@@ -358,6 +364,8 @@ sample:
           log:
             path: /path_to/case/mother/chanjo_sexcheck/mother_lanes_1_sorted_md_brecal_sex_chanjo_sexcheck.log
           path: /path_to/case/mother/chanjo_sexcheck/mother_lanes_1_sorted_md_brecal_sex.tsv
+      chromograph_ar:
+          path: /path_to/case/mother/chromograph_ar/mother_lanes_1234_sorted_md_brecal_tcov_chromograph.tar.gz
       collecthsmetrics:
         mother_lanes_1_sorted_md_brecal_collecthsmetrics:
           path: /path_to/case/mother/picardtools_collecthsmetrics/mother_lanes_1_sorted_md_brecal_collecthsmetrics

--- a/tests/mip/test_mip_files.py
+++ b/tests/mip/test_mip_files.py
@@ -111,7 +111,7 @@ def test_parse_sampleinfo(files_raw):
     # Sample data
     # Build dict for sample return data
     sampleinfo_test_sample_data = {
-        'bam': '/path_to/case/mother/gatk_baserecalibration/mother_lanes_1_sorted_md_brecal.cram',
+        'cram': '/path_to/case/mother/gatk_baserecalibration/mother_lanes_1_sorted_md_brecal.cram',
         'chanjo_sexcheck': (
             '/path_to/case/mother/chanjo_sexcheck/mother_lanes_1_sorted_md_brecal_sex.tsv'),
         'id': 'mother',

--- a/tests/mip/test_mip_files.py
+++ b/tests/mip/test_mip_files.py
@@ -93,11 +93,15 @@ def test_parse_sampleinfo(files_raw):
     sampleinfo_test_data = {
         'case': 'case',
         'genome_build': 'grch37',
+        'multiqc_html': '/path_to/case/case/multiqc_ar/multiqc_report.html',
+        'multiqc_json': '/path_to/case/case/multiqc_ar/multiqc_data/multiqc_data.json',
+        'pedigree': '/path_to/cases/case/case_pedigree.yaml',
         'pedigree_path': '/path_to/case/case.fam',
         'qcmetrics_path': '/path_to/case/case_qc_metrics.yaml',
         'sv_combinevariantcallsets_path':
             '/path_to/case/case/sv_combinevariantcallsets/case_comb.vcf',
         'version': 'v7.1.0',
+        'version_collect': '/path_to/case/case/version_collect_ar/case_vcol.yaml',
         }
 
     # Check returns from def 1
@@ -107,10 +111,11 @@ def test_parse_sampleinfo(files_raw):
     # Sample data
     # Build dict for sample return data
     sampleinfo_test_sample_data = {
-        'bam': '/path_to/case/mother/gatk_baserecalibration/mother_lanes_1_sorted_md_brecal.bam',
+        'bam': '/path_to/case/mother/gatk_baserecalibration/mother_lanes_1_sorted_md_brecal.cram',
         'chanjo_sexcheck': (
             '/path_to/case/mother/chanjo_sexcheck/mother_lanes_1_sorted_md_brecal_sex.tsv'),
         'id': 'mother',
+        'chromograph': '/path_to/case/mother/chromograph_ar/mother_lanes_1234_sorted_md_brecal_tcov_chromograph.tar.gz',
         'sambamba': ('/path_to/case/mother/sambamba_depth'
                      '/mother_lanes_1_sorted_md_brecal_coverage.bed'),
         'sex': 'female',

--- a/tests/mip/test_mip_files.py
+++ b/tests/mip/test_mip_files.py
@@ -192,18 +192,6 @@ def test_parse_qcmetrics(files_raw):
     # THEN it should work ;-)
     assert isinstance(qcmetrics_data, dict)
 
-    # Version data
-    # Build dict for version return data
-    qcmetrics_test_version_data = {
-        'gatk': '3.8',
-        'manta': '1.5.0',
-        'vep': 'v95',
-        }
-
-    # Check returns from def
-    for key, value in qcmetrics_test_version_data.items():
-        assert qcmetrics_data['versions'][key] == value
-
     # Sample data
     # Build dict for sample return data
     qcmetrics_test_sample_data = {

--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -69,10 +69,9 @@ def parse_sampleinfo(data: dict) -> dict:
         'date': data['analysis_date'],
         'case': data['case'],
         'genome_build': genome_build_str,
-        'rank_model_version': data['recipe']['genmod']['rank_model']['version'],
-        'sv_rank_model_version': data['recipe']['sv_genmod']['sv_rank_model']['version'],
         'is_finished': True if data['analysisrunstatus'] == 'finished' else False,
-        'pedigree_path': data['pedigree_minimal'],
+        'multiqc_html': data['recipe']['multiqc'][data['case'] + '_html']['path'],
+        'multiqc_json': data['recipe']['multiqc'][data['case'] + '_json']['path'],
         'peddy': {
             'ped': (data['recipe']['peddy_ar']['peddy']['path'] if
                     'peddy_ar' in data['recipe'] else None),
@@ -81,14 +80,17 @@ def parse_sampleinfo(data: dict) -> dict:
             'sex_check': (data['recipe']['peddy_ar']['sex_check']['path'] if
                           'peddy_ar' in data['recipe'] else None),
         },
+        'pedigree': data['pedigree_file']['path'],
+        'pedigree_path': data['pedigree_minimal'],
         'qcmetrics_path': data['recipe']['qccollect_ar']['path'],
+        'rank_model_version': data['recipe']['genmod']['rank_model']['version'],
         'samples': [],
         'snv': {
             'bcf': data['most_complete_bcf']['path'],
             'clinical_vcf': data['vcf_binary_file']['clinical']['path'],
             'research_vcf': data['vcf_binary_file']['research']['path'],
         },
-        'sv_combinevariantcallsets_path': sv_combinevariantcallsets_path,
+        'str_vcf': data['recipe'].get('expansionhunter', {}).get('path'),
         'sv': {
             'bcf': data['recipe']['sv_combinevariantcallsets'].get('sv_bcf_file', {}).get('path'),
             'clinical_vcf': (data['sv_vcf_binary_file']['clinical']['path'] if
@@ -97,14 +99,19 @@ def parse_sampleinfo(data: dict) -> dict:
             'research_vcf': (data['sv_vcf_binary_file']['research']['path'] if
                              'sv_vcf_binary_file' in data else None),
         },
+        'sv_rank_model_version': data['recipe']['sv_genmod']['sv_rank_model']['version'],
+        'sv_combinevariantcallsets_path': sv_combinevariantcallsets_path,
         'version': data['mip_version'],
-        'str_vcf': data['recipe'].get('expansionhunter', {}).get('path')
+        'version_collect': data['recipe']['version_collect_ar']['path'],
     }
 
     for sample_id, sample_data in data['sample'].items():
         sample = {
             'id': sample_id,
             'bam': sample_data['most_complete_bam']['path'],
+            # chromograph is only for wgs and trio data
+            'chromograph': (sample_data['recipe']['chromograph_ar']['path']  if 'chromograph_ar' in sample_data['recipe']
+                             else None),
             'sambamba': list(sample_data['recipe']['sambamba_depth'].values())[0]['path'],
             'sex': sample_data['sex'],
             # subsample mt is only for wgs data

--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -108,7 +108,7 @@ def parse_sampleinfo(data: dict) -> dict:
     for sample_id, sample_data in data['sample'].items():
         sample = {
             'id': sample_id,
-            'bam': sample_data['most_complete_bam']['path'],
+            'cram': sample_data['most_complete_bam']['path'],
             # chromograph is only for wgs and trio data
             'chromograph': (sample_data['recipe']['chromograph_ar']['path']  if 'chromograph_ar' in sample_data['recipe']
                              else None),

--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -136,11 +136,6 @@ def parse_qcmetrics(metrics: dict) -> dict:
         dict: parsed data
     """
     data = {
-        'versions': {
-            'gatk': metrics['recipe']['gatk']['version'],
-            'manta': metrics['recipe'].get('manta', {}).get('version'),
-            'vep': metrics['recipe'].get('varianteffectpredictor', {}).get('version'),
-        },
         'samples': [],
     }
 


### PR DESCRIPTION
This PR adds new files to transfer from MIP 8 and removes the ability to transfer bam files and will only transfer cram files.

**How to test**:
1. install on stage: bash servers/resources/coffee.scilifelab.se/update-trailblazer-stage.sh mip-dna-v8.2
1. Testing will be done in: https://github.com/Clinical-Genomics/cg/pull/542

**Expected outcome**:
Traiblazer will transfer MIP 8.2 files

**Review:**
- [x] code approved by @patrikgrenfeldt 
- [x] tests executed by @henrikstranneheim 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is major **version bump** because we are making incompatible changes