### PR TITLE
remove pytest-flask from prod deps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=3.6                 # due to  pytest-cov, pytest-flask
+pytest>=5.2                 # due to  pytest-cov, pytest-flask
 pytest-cov
 pytest-flask
 coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ Flask-SQLAlchemy==2.1
 Flask-CORS
 Flask-Reverse-Proxy
 google-auth
-pytest-flask
 
 # misc
 pymysql


### PR DESCRIPTION
This PR removes the pytest requirements for the prod env since it should not be installed in prod

**How to test**:
1. look at travis checks 

**Expected outcome**:
- [x] travis checks should pass
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @jemten 
- [x] tests executed by @patrikgrenfeldt 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is patch|| **version bump** because it's a fix
