### PR TITLE
Fix/cg clean mipauto mip backwards compat

### DIFF
--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -50,7 +50,7 @@ def parse_sampleinfo_light(data: dict) -> dict:
     return outdata
 
 
-def get_sample_date(data: dict) -> str:
+def get_sampleinfo_date(data: dict) -> str:
     """Get MIP sample info date.
 
     Args:

--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -49,6 +49,20 @@ def parse_sampleinfo_light(data: dict) -> dict:
 
     return outdata
 
+
+def get_sample_date(data: dict) -> str:
+    """Get MIP sample info date.
+
+    Args:
+        data (dict): raw YAML input from MIP qc sample info file
+
+    Returns:
+        str: analysis date
+    """
+
+    return data['analysis_date']
+
+
 def parse_sampleinfo(data: dict) -> dict:
     """Parse MIP sample info file.
 


### PR DESCRIPTION
This PR adds a fix for the broken cg clean auto
tested in: https://github.com/Clinical-Genomics/cg/pull/585

**Review:**
- [x] code approved by @adrosenbaum 
- [x] tests executed by @patrikgrenfeldt @henrikstranneheim 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is a minor **version bump** because we add functionality in a backwards compatible manner
