### PR TITLE
activate conda env before launching mip

### DIFF
--- a/tests/mip/conftest.py
+++ b/tests/mip/conftest.py
@@ -14,5 +14,5 @@ def failed_sacct_jobs():
 
 @pytest.fixture(scope='session')
 def mip_cli():
-    _mip_cli = start.MipCli(script='test/fake_mip.pl', pipeline='rd_dna')
+    _mip_cli = start.MipCli(script='test/fake_mip.pl', pipeline='rd_dna', conda_env='dummy_env')
     return _mip_cli

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -80,7 +80,7 @@ def log_cmd(context, sampleinfo, sacct, quiet, config):
 @click.pass_context
 def start(context, mip_config, email, priority, dryrun, command, start_with, case):
     """Start a new analysis."""
-    mip_cli = MipCli(context.obj['script'], context.obj['pipeline'])
+    mip_cli = MipCli(context.obj['script'], context.obj['pipeline'], context.obj['conda_env'])
     mip_config = mip_config or context.obj['mip_config']
     email = email or environ_email()
     kwargs = dict(config=mip_config, case=case, priority=priority,

--- a/trailblazer/mip/start.py
+++ b/trailblazer/mip/start.py
@@ -35,7 +35,6 @@ class MipCli(object):
         command = self.build_command(case, config, **kwargs)
         LOG.debug(' '.join(command))
         process = self.execute(command)
-        process.wait()
         if process.returncode != 0:
             raise MipStartError('error starting analysis, check the output')
         return process

--- a/trailblazer/mip/start.py
+++ b/trailblazer/mip/start.py
@@ -56,7 +56,7 @@ class MipCli(object):
     def execute(self, command):
         """Start a new MIP run."""
 
-        command.insert(0, f"bash -c 'conda activate {self.conda_env}; ")
+        command.insert(0, f"bash -c 'source activate {self.conda_env}; ")
         command.append("'")
 
         process = subprocess.run(" ".join(command), shell=True)

--- a/trailblazer/mip/start.py
+++ b/trailblazer/mip/start.py
@@ -24,10 +24,11 @@ class MipCli(object):
 
     """Wrapper around MIP command line interface."""
 
-    def __init__(self, script, pipeline):
+    def __init__(self, script, pipeline, conda_env):
         """Initialize MIP command line interface."""
         self.script = script
         self.pipeline = pipeline
+        self.conda_env = conda_env
 
     def __call__(self, config, case, **kwargs):
         """Execute the pipeline."""
@@ -55,12 +56,8 @@ class MipCli(object):
     def execute(self, command):
         """Start a new MIP run."""
 
-        """
-        Remove the default SIGPIPE handler
-        https://blog.nelhage.com/2010/02/a-very-subtle-bug/
-        """
-        process = subprocess.Popen(
-            command,
-            preexec_fn=lambda: signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-        )
+        command.insert(0, f"bash -c 'conda activate {self.conda_env}; ")
+        command.append("'")
+
+        process = subprocess.run(" ".join(command), shell=True)
         return process

--- a/trailblazer/mip/start.py
+++ b/trailblazer/mip/start.py
@@ -36,7 +36,8 @@ class MipCli(object):
         LOG.debug(' '.join(command))
         process = self.execute(command)
         if process.returncode != 0:
-            raise MipStartError('error starting analysis, check the output')
+            raise MipStartError(f"Error starting analysis: "
+                                f"{subprocess.CalledProcessError.stderr}")
         return process
 
     def build_command(self, case, config, **kwargs):
@@ -58,5 +59,5 @@ class MipCli(object):
         command.insert(0, f"bash -c 'source activate {self.conda_env}; ")
         command.append("'")
 
-        process = subprocess.run(" ".join(command), shell=True)
+        process = subprocess.run(" ".join(command), shell=True, check=True)
         return process


### PR DESCRIPTION
This PR adds:
- `source activate conda_env` before running MIP

**How to test**:
1. install on hasta stage: `bash stage/servers/resources/hasta.scilifelab.se/update-trailblazer-stage.sh feat/run-mip-in-conda`

**Expected outcome**:
- [ ] Trailblazer will start MIP by first sourcing MIPs conda environment

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
