### PR TITLE
Adatps validation behaviour to marshmallow > 3.0

### DIFF
--- a/tests/mip/test_mip_config.py
+++ b/tests/mip/test_mip_config.py
@@ -1,0 +1,149 @@
+"""Tests for the config functionality"""
+import pytest
+
+from trailblazer.mip import config as tb_config
+from trailblazer.exc import ConfigError
+
+def test_validate_config():
+    """Test to validate a correct config"""
+    # GIVEN a correct config
+    sample = dict(
+        sample_id = "sample",
+        analysis_type = 'wes',
+        father = '0',
+        mother = '0',
+        phenotype = 'affected',
+        sex = 'male',
+        expected_coverage = 15,
+        capture_kit = 'agilent_sureselect_cre.v1',
+    )
+
+    config = dict(
+        case = "a_case",
+        default_gene_panels = ["a_panel"],
+        samples = [sample],
+    )
+
+    # WHEN validating the config
+    errors = tb_config.ConfigHandler.validate_config(config)
+
+    # THEN assert the errors is a dict
+    assert isinstance(errors, dict)
+
+    # THEN assert there where no errors
+    assert errors == {}
+
+def test_validate_config_invalid_analysis_type():
+    """Test to validate a invalid config with wrong analysis type"""
+    # GIVEN a correct config
+    sample = dict(
+        sample_id = "sample",
+        analysis_type = 'nonexisting',
+        father = '0',
+        mother = '0',
+        phenotype = 'affected',
+        sex = 'male',
+        expected_coverage = 15,
+        capture_kit = 'agilent_sureselect_cre.v1',
+    )
+
+    config = dict(
+        case = "a_case",
+        default_gene_panels = ["a_panel"],
+        samples = [sample],
+    )
+
+    # WHEN validating the config
+    with pytest.raises(ConfigError):
+    # THEN assert a config error is raised
+        tb_config.ConfigHandler.validate_config(config)
+
+def test_validate_config_unknown_field():
+    """Test to validate a config with a unspecified field.
+
+    This should work since we allow unspecified fields
+    """
+    # GIVEN a correct config with a extra field
+    sample = dict(
+        sample_id = "sample",
+        sample_display_name = "ASAMPLENAME",
+        analysis_type = 'wes',
+        father = '0',
+        mother = '0',
+        phenotype = 'affected',
+        sex = 'male',
+        expected_coverage = 15,
+        capture_kit = 'agilent_sureselect_cre.v1',
+    )
+
+    config = dict(
+        case = "a_case",
+        default_gene_panels = ["a_panel"],
+        samples = [sample],
+    )
+
+    # WHEN validating the config
+    errors = tb_config.ConfigHandler.validate_config(config)
+
+    # THEN assert the errors is a dict
+    assert isinstance(errors, dict)
+
+    # THEN assert there where one error that could pass
+    assert len(errors) == 1
+
+def test_validate_config_unknown_field_and_missing_sample_id():
+    """Test to validate a config with a unspecified field and a missing mandatory field.
+
+    This should raise exception since we do not allow missing mandatory fields
+    """
+    # GIVEN a config with missing sample_id and an extra field
+    sample = dict(
+        sample_display_name = "ASAMPLENAME",
+        analysis_type = 'wes',
+        father = '0',
+        mother = '0',
+        phenotype = 'affected',
+        sex = 'male',
+        expected_coverage = 15,
+        capture_kit = 'agilent_sureselect_cre.v1',
+    )
+
+    config = dict(
+        case = "a_case",
+        default_gene_panels = ["a_panel"],
+        samples = [sample],
+    )
+
+    # WHEN validating the config
+    with pytest.raises(ConfigError):
+    # THEN assert a config error is raised
+        tb_config.ConfigHandler.validate_config(config)
+
+def test_validate_config_unknown_field_and_invalid_analysis_type():
+    """Test to validate a config with a unspecified field and a missing mandatory field.
+
+    This should raise exception since we do not allow wrong analysis types
+    """
+    # GIVEN a config with wrong analysis type and an extra field
+    sample = dict(
+        sample_id = "sample",
+        sample_display_name = "ASAMPLENAME",
+        analysis_type = 'nonexisting',
+        father = '0',
+        mother = '0',
+        phenotype = 'affected',
+        sex = 'male',
+        expected_coverage = 15,
+        capture_kit = 'agilent_sureselect_cre.v1',
+    )
+
+    config = dict(
+        case = "a_case",
+        default_gene_panels = ["a_panel"],
+        samples = [sample],
+    )
+
+    # WHEN validating the config
+    with pytest.raises(ConfigError):
+    # THEN assert a config error is raised
+        tb_config.ConfigHandler.validate_config(config)

--- a/tests/mip/test_mip_config.py
+++ b/tests/mip/test_mip_config.py
@@ -4,25 +4,22 @@ import pytest
 from trailblazer.mip import config as tb_config
 from trailblazer.exc import ConfigError
 
+
 def test_validate_config():
     """Test to validate a correct config"""
     # GIVEN a correct config
     sample = dict(
-        sample_id = "sample",
-        analysis_type = 'wes',
-        father = '0',
-        mother = '0',
-        phenotype = 'affected',
-        sex = 'male',
-        expected_coverage = 15,
-        capture_kit = 'agilent_sureselect_cre.v1',
+        sample_id="sample",
+        analysis_type="wes",
+        father="0",
+        mother="0",
+        phenotype="affected",
+        sex="male",
+        expected_coverage=15,
+        capture_kit="agilent_sureselect_cre.v1",
     )
 
-    config = dict(
-        case = "a_case",
-        default_gene_panels = ["a_panel"],
-        samples = [sample],
-    )
+    config = dict(case="a_case", default_gene_panels=["a_panel"], samples=[sample],)
 
     # WHEN validating the config
     errors = tb_config.ConfigHandler.validate_config(config)
@@ -33,30 +30,28 @@ def test_validate_config():
     # THEN assert there where no errors
     assert errors == {}
 
+
 def test_validate_config_invalid_analysis_type():
     """Test to validate a invalid config with wrong analysis type"""
     # GIVEN a correct config
     sample = dict(
-        sample_id = "sample",
-        analysis_type = 'nonexisting',
-        father = '0',
-        mother = '0',
-        phenotype = 'affected',
-        sex = 'male',
-        expected_coverage = 15,
-        capture_kit = 'agilent_sureselect_cre.v1',
+        sample_id="sample",
+        analysis_type="nonexisting",
+        father="0",
+        mother="0",
+        phenotype="affected",
+        sex="male",
+        expected_coverage=15,
+        capture_kit="agilent_sureselect_cre.v1",
     )
 
-    config = dict(
-        case = "a_case",
-        default_gene_panels = ["a_panel"],
-        samples = [sample],
-    )
+    config = dict(case="a_case", default_gene_panels=["a_panel"], samples=[sample],)
 
     # WHEN validating the config
     with pytest.raises(ConfigError):
-    # THEN assert a config error is raised
+        # THEN assert a config error is raised
         tb_config.ConfigHandler.validate_config(config)
+
 
 def test_validate_config_unknown_field():
     """Test to validate a config with a unspecified field.
@@ -65,22 +60,18 @@ def test_validate_config_unknown_field():
     """
     # GIVEN a correct config with a extra field
     sample = dict(
-        sample_id = "sample",
-        sample_display_name = "ASAMPLENAME",
-        analysis_type = 'wes',
-        father = '0',
-        mother = '0',
-        phenotype = 'affected',
-        sex = 'male',
-        expected_coverage = 15,
-        capture_kit = 'agilent_sureselect_cre.v1',
+        sample_id="sample",
+        sample_display_name="ASAMPLENAME",
+        analysis_type="wes",
+        father="0",
+        mother="0",
+        phenotype="affected",
+        sex="male",
+        expected_coverage=15,
+        capture_kit="agilent_sureselect_cre.v1",
     )
 
-    config = dict(
-        case = "a_case",
-        default_gene_panels = ["a_panel"],
-        samples = [sample],
-    )
+    config = dict(case="a_case", default_gene_panels=["a_panel"], samples=[sample],)
 
     # WHEN validating the config
     errors = tb_config.ConfigHandler.validate_config(config)
@@ -91,6 +82,7 @@ def test_validate_config_unknown_field():
     # THEN assert there where one error that could pass
     assert len(errors) == 1
 
+
 def test_validate_config_unknown_field_and_missing_sample_id():
     """Test to validate a config with a unspecified field and a missing mandatory field.
 
@@ -98,26 +90,23 @@ def test_validate_config_unknown_field_and_missing_sample_id():
     """
     # GIVEN a config with missing sample_id and an extra field
     sample = dict(
-        sample_display_name = "ASAMPLENAME",
-        analysis_type = 'wes',
-        father = '0',
-        mother = '0',
-        phenotype = 'affected',
-        sex = 'male',
-        expected_coverage = 15,
-        capture_kit = 'agilent_sureselect_cre.v1',
+        sample_display_name="ASAMPLENAME",
+        analysis_type="wes",
+        father="0",
+        mother="0",
+        phenotype="affected",
+        sex="male",
+        expected_coverage=15,
+        capture_kit="agilent_sureselect_cre.v1",
     )
 
-    config = dict(
-        case = "a_case",
-        default_gene_panels = ["a_panel"],
-        samples = [sample],
-    )
+    config = dict(case="a_case", default_gene_panels=["a_panel"], samples=[sample],)
 
     # WHEN validating the config
     with pytest.raises(ConfigError):
-    # THEN assert a config error is raised
+        # THEN assert a config error is raised
         tb_config.ConfigHandler.validate_config(config)
+
 
 def test_validate_config_unknown_field_and_invalid_analysis_type():
     """Test to validate a config with a unspecified field and a missing mandatory field.
@@ -126,24 +115,20 @@ def test_validate_config_unknown_field_and_invalid_analysis_type():
     """
     # GIVEN a config with wrong analysis type and an extra field
     sample = dict(
-        sample_id = "sample",
-        sample_display_name = "ASAMPLENAME",
-        analysis_type = 'nonexisting',
-        father = '0',
-        mother = '0',
-        phenotype = 'affected',
-        sex = 'male',
-        expected_coverage = 15,
-        capture_kit = 'agilent_sureselect_cre.v1',
+        sample_id="sample",
+        sample_display_name="ASAMPLENAME",
+        analysis_type="nonexisting",
+        father="0",
+        mother="0",
+        phenotype="affected",
+        sex="male",
+        expected_coverage=15,
+        capture_kit="agilent_sureselect_cre.v1",
     )
 
-    config = dict(
-        case = "a_case",
-        default_gene_panels = ["a_panel"],
-        samples = [sample],
-    )
+    config = dict(case="a_case", default_gene_panels=["a_panel"], samples=[sample],)
 
     # WHEN validating the config
     with pytest.raises(ConfigError):
-    # THEN assert a config error is raised
+        # THEN assert a config error is raised
         tb_config.ConfigHandler.validate_config(config)

--- a/trailblazer/mip/config.py
+++ b/trailblazer/mip/config.py
@@ -15,18 +15,16 @@ LOG = logging.getLogger(__name__)
 class SampleSchema(Schema):
     sample_id = fields.Str(required=True)
     analysis_type = fields.Str(
-        required=True,
-        validate=validate.OneOf(choices=['wes', 'wgs', 'tga'])
+        required=True, validate=validate.OneOf(choices=["wes", "wgs", "tga"])
     )
-    father = fields.Str(default='0')
-    mother = fields.Str(default='0')
+    father = fields.Str(default="0")
+    mother = fields.Str(default="0")
     phenotype = fields.Str(
         required=True,
-        validate=validate.OneOf(choices=['affected', 'unaffected', 'unknown'])
+        validate=validate.OneOf(choices=["affected", "unaffected", "unknown"]),
     )
     sex = fields.Str(
-        required=True,
-        validate=validate.OneOf(choices=['male', 'female', 'unknown'])
+        required=True, validate=validate.OneOf(choices=["male", "female", "unknown"])
     )
     expected_coverage = fields.Float()
     capture_kit = fields.Str(default=DEFAULT_CAPTURE_KIT)
@@ -40,19 +38,15 @@ class ConfigSchema(Schema):
 
 class SampleSchemaRNA(Schema):
     sample_id = fields.Str(required=True)
-    analysis_type = fields.Str(
-        required=True,
-        validate=validate.OneOf(choices=['wts'])
-    )
-    father = fields.Str(default='0')
-    mother = fields.Str(default='0')
+    analysis_type = fields.Str(required=True, validate=validate.OneOf(choices=["wts"]))
+    father = fields.Str(default="0")
+    mother = fields.Str(default="0")
     phenotype = fields.Str(
         required=True,
-        validate=validate.OneOf(choices=['affected', 'unaffected', 'unknown'])
+        validate=validate.OneOf(choices=["affected", "unaffected", "unknown"]),
     )
     sex = fields.Str(
-        required=True,
-        validate=validate.OneOf(choices=['male', 'female', 'unknown'])
+        required=True, validate=validate.OneOf(choices=["male", "female", "unknown"])
     )
     expected_coverage = fields.Float()
     capture_kit = fields.Str(default=DEFAULT_CAPTURE_KIT)
@@ -65,7 +59,6 @@ class ConfigSchemaRNA(Schema):
 
 
 class ConfigHandler:
-
     def make_config(self, data: dict, pipeline: str = None):
         """Make a MIP config."""
         self.validate_config(data, pipeline)
@@ -75,7 +68,7 @@ class ConfigHandler:
     @staticmethod
     def validate_config(data: dict, pipeline: str = None) -> dict:
         """Convert to MIP config format."""
-        if pipeline == 'mip-rna':
+        if pipeline == "mip-rna":
             errors = ConfigSchemaRNA().validate(data)
         else:
             errors = ConfigSchema().validate(data)
@@ -85,19 +78,21 @@ class ConfigHandler:
                 if isinstance(messages, dict):
                     for level, sample_errors in messages.items():
                         try:
-                            sample_id = data['samples'][level]['sample_id']
+                            sample_id = data["samples"][level]["sample_id"]
                         except KeyError:
-                            raise ConfigError('missing sample id')
+                            raise ConfigError("missing sample id")
 
                         for sub_field, sub_messages in sample_errors.items():
                             if sub_messages != ["Unknown field."]:
                                 hard_error = True
-                            LOG.error(f"{sample_id} -> {sub_field}: {', '.join(sub_messages)}")
+                            LOG.error(
+                                f"{sample_id} -> {sub_field}: {', '.join(sub_messages)}"
+                            )
                 else:
                     hard_error = True
                     LOG.error(f"{field}: {', '.join(messages)}")
             if hard_error:
-                raise ConfigError('invalid config input', errors=errors)
+                raise ConfigError("invalid config input", errors=errors)
         return errors
 
     @staticmethod
@@ -105,23 +100,26 @@ class ConfigHandler:
         """Prepare the config data."""
         data_copy = deepcopy(data)
         # handle single sample cases with 'unknown' phenotype
-        if len(data_copy['samples']) == 1:
-            if data_copy['samples'][0]['phenotype'] == 'unknown':
+        if len(data_copy["samples"]) == 1:
+            if data_copy["samples"][0]["phenotype"] == "unknown":
                 LOG.info("setting 'unknown' phenotype to 'unaffected'")
-                data_copy['samples'][0]['phenotype'] = 'unaffected'
+                data_copy["samples"][0]["phenotype"] = "unaffected"
         # set the mother/father to '0' if they are not set for a sample
-        for sample_data in data_copy['samples']:
-            sample_data['mother'] = sample_data.get('mother') or '0'
-            sample_data['father'] = sample_data.get('father') or '0'
-            if sample_data['analysis_type'] == 'wgs' and sample_data.get('capture_kit') is None:
-                sample_data['capture_kit'] = DEFAULT_CAPTURE_KIT
+        for sample_data in data_copy["samples"]:
+            sample_data["mother"] = sample_data.get("mother") or "0"
+            sample_data["father"] = sample_data.get("father") or "0"
+            if (
+                sample_data["analysis_type"] == "wgs"
+                and sample_data.get("capture_kit") is None
+            ):
+                sample_data["capture_kit"] = DEFAULT_CAPTURE_KIT
         return data_copy
 
     def save_config(self, data: dict) -> Path:
         """Save a config to the expected location."""
-        out_dir = Path(self.families_dir) / data['case']
+        out_dir = Path(self.families_dir) / data["case"]
         out_dir.mkdir(parents=True, exist_ok=True)
-        out_path = out_dir / 'pedigree.yaml'
+        out_path = out_dir / "pedigree.yaml"
         dump = ruamel.yaml.round_trip_dump(data, indent=4, block_seq_indent=2)
         out_path.write_text(dump)
         return out_path


### PR DESCRIPTION
This PR fixes a problem that arises when marshmallow is upgraded to versions > 3.0.

Before the validation of a schema was only strict if specified explicitly. The result was that when unspecified fields in the config existed the validation passed. From marshmallow v3.0 all schemas became strict by default and this is nothing that can be changed. More about this [here](https://marshmallow.readthedocs.io/en/stable/upgrading.html#schemas-are-always-strict)
In this PR we handle the problems with missing fields in the schema definitions, that is we let these error pass.
The long term solution would be to do strict validations and instead update the schemas when configs change.

## How to test

- [x] Log into hasta: `ssh hasta`
- [x] Activate stage: `us`
- [x] Paxa trailblazer: `paxa`
- [x] Install this branch on stage: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-trailblazer-stage.sh fix-marshmallow-validation`
- [x] Try to start an analysis: `cg workflow mip-dna -c givingburro`

## Expected test outcome

- [ ] The functionality should be working
- [ ] Take a screenshot and post here

## Review
- [x] code approved by @b4ckm4n 
- [x] tests executed by @b4ckm4n 
- [x] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions