### PR TITLE
feat(parse_mip): Added check for version_collect recipe key and default

### DIFF
--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -116,7 +116,8 @@ def parse_sampleinfo(data: dict) -> dict:
         'sv_rank_model_version': data['recipe']['sv_genmod']['sv_rank_model']['version'],
         'sv_combinevariantcallsets_path': sv_combinevariantcallsets_path,
         'version': data['mip_version'],
-        'version_collect': data['recipe']['version_collect_ar']['path'],
+        'version_collect': (data['recipe']['version_collect_ar']['path']  if
+                             'version_collect_ar' in data['recipe'] else None),
     }
 
     for sample_id, sample_data in data['sample'].items():


### PR DESCRIPTION
if not found

This PR adds a fix for missing version_collect_recipe key in sampleinfo.

**How to test**:
1. install on stage of hasta: `/home/proj/stage/servers/resources/hasta.scilifelab.se/update-trailblazer-stage.sh mip_parse_sampleinfo`
1. activate stage: `us`
1. run following command: `cg upload delivery-report firmquagga --print`

**Expected outcome**:
- The error get_latest_metadata error should be gone:
![Screenshot 2020-08-05 at 08 33 04](https://user-images.githubusercontent.com/584738/89379565-4966e380-d6f6-11ea-837c-a0d64bf34aaa.png)


**Review:**
- [ ] code approved by
- [x] tests executed by @henrikstranneheim 
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch **version bump** because it fixes a bug in a backwards compatible manner
