### PR TITLE
feat(case): Added functions to get case from config and from sampleinfo

### DIFF
--- a/tests/mip/test_mip_files.py
+++ b/tests/mip/test_mip_files.py
@@ -6,6 +6,30 @@ import dateutil
 from trailblazer.mip import files
 
 
+def test_get_case_from_config_when_case_id():
+    """Test getting the case id from mip config"""
+    # GIVEN a case id
+    config = {"case_id": "crazygoat"}
+
+    # WHEN getting case from config dict
+    case = files.get_case_from_config(config=config)
+
+    # THEN return case
+    assert case == "crazygoat"
+
+
+def test_get_case_from_config_when_family_id():
+    """Test getting the case id from mip config"""
+    # GIVEN a case id
+    config = {"family_id": "crazygoat"}
+
+    # WHEN getting case from config dict
+    case = files.get_case_from_config(config=config)
+
+    # THEN return case
+    assert case == "crazygoat"
+
+
 def test_parse_config(files_raw) -> dict:
     """
     Args:
@@ -99,6 +123,30 @@ def test_get_rank_model_version_with_program(files_raw: dict, mip_meta_data: dic
 
     # THEN the rank model version should be returned
     assert rank_model_version == mip_meta_data["RANK_MODEL_VERSION"]
+
+
+def test_get_case_from_sampleinfo_when_case():
+    """Test getting the case id from mip sampleinfo file"""
+    # GIVEN a case id
+    config = {"case": "crazygoat"}
+
+    # WHEN getting case from config dict
+    case = files.get_case_from_sampleinfo(sample_info=config)
+
+    # THEN return case
+    assert case == "crazygoat"
+
+
+def test_get_case_from_sampleinfo_when_family():
+    """Test getting the case id from mip sampleinfo file"""
+    # GIVEN a case id
+    config = {"family": "crazygoat"}
+
+    # WHEN getting case from config dict
+    case = files.get_case_from_sampleinfo(sample_info=config)
+
+    # THEN return case
+    assert case == "crazygoat"
 
 
 def test_parse_sampleinfo(files_raw: dict):

--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -10,6 +10,7 @@ def get_case_from_config(config: dict) -> str:
         return config["case_id"]
     if "family_id" in config:  # family for MIP<7
         return config["family_id"]
+    return None
 
 
 def parse_config(data: dict) -> dict:
@@ -75,6 +76,7 @@ def get_case_from_sampleinfo(sample_info: dict) -> str:
         return sample_info["case"]
     if "family" in sample_info:  # family for MIP<7
         return sample_info["family"]
+    return None
 
 
 def get_rank_model_version(sample_info: dict, rank_model_type: str, step: str) -> str:

--- a/trailblazer/mip/files.py
+++ b/trailblazer/mip/files.py
@@ -4,6 +4,14 @@
 PED_SEX_MAP = {1: "male", 2: "female", 0: "unknown"}
 
 
+def get_case_from_config(config: dict) -> str:
+    """Get case id from config"""
+    if "case_id" in config:
+        return config["case_id"]
+    if "family_id" in config:  # family for MIP<7
+        return config["family_id"]
+
+
 def parse_config(data: dict) -> dict:
     """Parse MIP config file.
 
@@ -15,7 +23,7 @@ def parse_config(data: dict) -> dict:
     """
     return {
         "email": data.get("email"),
-        "case": data["case_id"] if "case_id" in data else data["family_id"],  # family_id for MIP<7
+        "case": get_case_from_config(config=data),
         "samples": [
             {"id": sample_id, "type": analysis_type}
             for sample_id, analysis_type in data["analysis_type"].items()
@@ -61,6 +69,14 @@ def get_sampleinfo_date(data: dict) -> str:
     return data["analysis_date"]
 
 
+def get_case_from_sampleinfo(sample_info: dict) -> str:
+    """Get case id from sampleinfo"""
+    if "case" in sample_info:
+        return sample_info["case"]
+    if "family" in sample_info:  # family for MIP<7
+        return sample_info["family"]
+
+
 def get_rank_model_version(sample_info: dict, rank_model_type: str, step: str) -> str:
     """Get rank model version"""
     rank_model_version = None
@@ -85,7 +101,7 @@ def parse_sampleinfo(data: dict) -> dict:
     outdata = {
         "date": data["analysis_date"],
         "genome_build": genome_build_str,
-        "case": data["case"],
+        "case": get_case_from_sampleinfo(sample_info=data),
         "is_finished": True if data["analysisrunstatus"] == "finished" else False,
         "rank_model_version": get_rank_model_version(
             sample_info=data, rank_model_type="rank_model", step="genmod"


### PR DESCRIPTION
This PR adds/fixes:

- Added functions to get case from config and from sampleinfo

### How to prepare for test
- [x] ssh to hasta
- [x] activate stage: `us`
- [x] request trailblazer-stage on hasta: `paxa`
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-trailblazer-stage.sh case_id_again`

### How to test
- [x] login to hasta
- [x] do `us`
- [x] Copy a fresh statusdb to stage and add the yaml files for the run to the stage HK bundle
1. `cg upload delivery-report -f -p quicksnail`
- [x] Remove the analysis record for MIP version 8.2 for quicksnail in statusdb
1. `cg upload delivery-report -f-p quicksnail`

### Expected test outcome
1. check that a delivery report can be created for MIP version 8.2 with missing values: "target_coverage, target_completeness", which are taken from the chanjo database and trailblazer and MIP ✅ 
1. check that a delivery report can be created for MIP version 6.0 with missing values: "target_coverage, target_completeness", whi ch are taken from the chanjo database and trailblazer and MIP ✅ 


## Review
- [x] code approved by AJ
- [x] tests executed by HS
- [x] "Merge and deploy" approved by HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
