### PR TITLE
Remove comment when completed, add cli command to complete analysis

### DIFF
--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import trailblazer
 from trailblazer.cli import base
-from trailblazer.cli.core import ls_cmd, delete, cancel, scan, user
+from trailblazer.cli.core import ls_cmd, delete, cancel, scan, user, set_analysis_completed
 import pytest
 
 
@@ -14,6 +14,28 @@ def test_base(cli_runner):
     # THEN it should print the name and version of the tool only
     assert trailblazer.__title__ in result.output
     assert trailblazer.__version__ in result.output
+
+
+def test_set_analysis_completed(cli_runner, trailblazer_context, caplog):
+
+    # GIVEN an analysis with status FAILED
+    failed_analysis = "crackpanda"
+    analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(case_id=failed_analysis)
+
+    # Make sure status is not "completed"
+    assert analysis_obj.status != "completed"
+
+    # WHEN running command
+    result = cli_runner.invoke(
+        set_analysis_completed, [str(analysis_obj.id)], obj=trailblazer_context
+    )
+
+    # THEN command runs successfully
+    assert result.exit_code == 0
+
+    # THEN status will be set to COMPLETED
+    analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(case_id=failed_analysis)
+    assert analysis_obj.status == "completed"
 
 
 def test_cancel_nonexistent(cli_runner, trailblazer_context, caplog):

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 @click.version_option(trailblazer.__version__, prog_name=trailblazer.__title__)
 @click.pass_context
 def base(context, config, database, log_level):
-    """Trailblazer - Simplify running MIP!"""
+    """Trailblazer - Tracking ongoing analyses!"""
     coloredlogs.install(level=log_level)
 
     context.obj = ruamel.yaml.safe_load(config) if config else {}
@@ -50,7 +50,7 @@ def init(context, reset, force):
 @base.command()
 @click.pass_context
 def scan(context):
-    """Scan a directory for analyses."""
+    """Scan ongoing analyses in SLURM."""
     context.obj["trailblazer"].update_ongoing_analyses()
     LOG.info("All analyses updated!")
 

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 @click.version_option(trailblazer.__version__, prog_name=trailblazer.__title__)
 @click.pass_context
 def base(context, config, database, log_level):
-    """Trailblazer - Tracking ongoing analyses!"""
+    """Trailblazer - Monitor analyses"""
     coloredlogs.install(level=log_level)
 
     context.obj = ruamel.yaml.safe_load(config) if config else {}
@@ -50,7 +50,7 @@ def init(context, reset, force):
 @base.command()
 @click.pass_context
 def scan(context):
-    """Scan ongoing analyses in SLURM."""
+    """Scan ongoing analyses in SLURM"""
     context.obj["trailblazer"].update_ongoing_analyses()
     LOG.info("All analyses updated!")
 
@@ -59,7 +59,7 @@ def scan(context):
 @click.argument("analysis_id")
 @click.pass_context
 def update_analysis(context, analysis_id: int):
-    """Update status of a single analysis."""
+    """Update status of a single analysis"""
     context.obj["trailblazer"].update_run_status(analysis_id=analysis_id)
 
 

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -59,7 +59,7 @@ def scan(context):
 @click.argument("analysis_id")
 @click.pass_context
 def update_analysis(context, analysis_id: int):
-    """Update a single analysis."""
+    """Update status of a single analysis."""
     context.obj["trailblazer"].update_run_status(analysis_id=analysis_id)
 
 

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -55,7 +55,7 @@ def scan(context):
     LOG.info("All analyses updated!")
 
 
-@base.command()
+@base.command("update-analysis")
 @click.argument("analysis_id")
 @click.pass_context
 def update_analysis(context, analysis_id: int):
@@ -86,6 +86,17 @@ def cancel(context, analysis_id):
     """Cancel all jobs in a run."""
     try:
         context.obj["trailblazer"].cancel_analysis(analysis_id=analysis_id, email=environ_email())
+    except Exception as e:
+        LOG.error(e)
+
+
+@base.command("set-completed")
+@click.argument("analysis_id", type=int)
+@click.pass_context
+def set_analysis_completed(context, analysis_id):
+    """Set status of an analysis to "COMPLETED" """
+    try:
+        context.obj["trailblazer"].set_analysis_completed(analysis_id=analysis_id)
     except Exception as e:
         LOG.error(e)
 

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -221,7 +221,7 @@ class BaseHandler:
         analysis_obj = self.analysis(analysis_id=analysis_id)
         analysis_obj.status = "completed"
         self.commit()
-        LOG.info(f"{analysis_obj.family} - status set to COMPETED")
+        LOG.info(f"{analysis_obj.family} - status set to COMPLETED")
 
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:
         """Delete the analysis output."""

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -217,6 +217,11 @@ class BaseHandler:
             self.commit()
         return old_analyses
 
+    def set_analysis_completed(self, analysis_id: int) -> None:
+        analysis_obj = self.analysis(analysis_id=analysis_id)
+        analysis_obj.status = "completed"
+        self.commit()
+
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:
         """Delete the analysis output."""
         analysis_obj = self.analysis(analysis_id=analysis_id)
@@ -382,19 +387,8 @@ class BaseHandler:
 
             elif status_distribution.get("COMPLETED") == 1:
                 analysis_obj.status = "completed"
-                elapsed_time = str(
-                    dt.datetime.now()
-                    - min(
-                        [
-                            job_obj.started_at
-                            for job_obj in analysis_obj.failed_jobs
-                            if job_obj.started_at
-                        ]
-                    )
-                )
-                analysis_obj.comment = (
-                    f"Run finished! Time elapsed " f"{elapsed_time.split('.')[0]}"
-                )
+                analysis_obj.comment = None
+
             elif status_distribution.get("RUNNING") or status_distribution.get("COMPLETED"):
                 analysis_obj.status = "running"
                 elapsed_time = str(

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -349,6 +349,15 @@ class BaseHandler:
                     f"Failed to update {analysis_obj.family} - {analysis_obj.id}: {e.__class__.__name__}"
                 )
 
+    def get_elapsed_time(self, analysis_obj: models.Analysis) -> str:
+        """Get elapsed time for the analysis"""
+        return str(
+            dt.datetime.now()
+            - min(
+                [job_obj.started_at for job_obj in analysis_obj.failed_jobs if job_obj.started_at]
+            )
+        )
+
     def update_run_status(self, analysis_id: int, ssh: bool = False) -> None:
         """Query slurm for entries related to given analysis, and update the Trailblazer database"""
         analysis_obj = self.analysis(analysis_id)
@@ -389,21 +398,12 @@ class BaseHandler:
                 analysis_obj.status = "completed"
                 analysis_obj.comment = None
 
-            elif status_distribution.get("RUNNING") or status_distribution.get("COMPLETED"):
-                analysis_obj.status = "running"
-                elapsed_time = str(
-                    dt.datetime.now()
-                    - min(
-                        [
-                            job_obj.started_at
-                            for job_obj in analysis_obj.failed_jobs
-                            if job_obj.started_at
-                        ]
-                    )
-                )
-                analysis_obj.comment = f"Running! Time elapsed " f"{elapsed_time.split('.')[0]}"
             elif status_distribution.get("PENDING") == 1:
                 analysis_obj.status = "pending"
+
+            elif status_distribution.get("RUNNING") or status_distribution.get("COMPLETED"):
+                analysis_obj.status = "running"
+
             elif status_distribution.get("CANCELLED") and not (
                 status_distribution.get("RUNNING") or status_distribution.get("PENDING")
             ):

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -221,6 +221,7 @@ class BaseHandler:
         analysis_obj = self.analysis(analysis_id=analysis_id)
         analysis_obj.status = "completed"
         self.commit()
+        LOG.info(f"{analysis_obj.family} - status set to COMPETED")
 
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:
         """Delete the analysis output."""


### PR DESCRIPTION
This PR adds/fixes ...

- Adds command line option 
`trailblazer set-completed [ANALYSIS ID]` - Set analysis to completed by ID from command line

- Removes elapsed time from comment


### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] activate stage: `us`
- [x] request trailblazer-stage on hasta: `paxa`
- [x] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-trailblazer-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] login to hasta and us
- [x] do trailblazer set-completed <analysis_id>

### Expected test outcome
- [x] check that analysis status set to completed
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by HS
- [x] tests executed by MR
- [x] "Merge and deploy" approved by MR
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **MINOR** - when you add functionality in a backwards compatible manner
