### PR TITLE
lock sqlalchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Alchy
 Click<7
 coloredlogs
 ruamel.yaml
-SQLAlchemy
+SQLAlchemy<1.4
 marshmallow
 tabulate
 python-dateutil


### PR DESCRIPTION
This PR adds/fixes ...
Lock Sqlalchemy version to 1.3
This breaks both tb and cg because tb is still installed in s_main

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
