### PR TITLE
adding ticket to trailblazer

### DIFF
--- a/alembic/versions/85f409b2eeeb_add_ticket_number.py
+++ b/alembic/versions/85f409b2eeeb_add_ticket_number.py
@@ -1,4 +1,4 @@
-"""empty message
+"""adds the ticket number for an analysis in the database
 
 Revision ID: 85f409b2eeeb
 Revises: dd72c72e23a2

--- a/alembic/versions/85f409b2eeeb_add_ticket_number.py
+++ b/alembic/versions/85f409b2eeeb_add_ticket_number.py
@@ -17,7 +17,7 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.add_column("analysis", sa.Column("ticket", sa.String(), nullable=True))
+    op.add_column("analysis", sa.Column("ticket", sa.String(32), nullable=True))
 
 
 def downgrade():

--- a/alembic/versions/85f409b2eeeb_add_ticket_number.py
+++ b/alembic/versions/85f409b2eeeb_add_ticket_number.py
@@ -17,8 +17,8 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.add_column("analysis", sa.Column("ticket", sa.String(32), nullable=True))
+    op.add_column("analysis", sa.Column("ticket_id", sa.String(32), nullable=True))
 
 
 def downgrade():
-    op.drop_column("analysis", "ticket")
+    op.drop_column("analysis", "ticket_id")

--- a/alembic/versions/85f409b2eeeb_add_ticket_number.py
+++ b/alembic/versions/85f409b2eeeb_add_ticket_number.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 85f409b2eeeb
+Revises: dd72c72e23a2
+Create Date: 2022-11-11 11:27:17.102596
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "85f409b2eeeb"
+down_revision = "dd72c72e23a2"
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column("analysis", sa.Column("ticket", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("analysis", "ticket")

--- a/tests/fixtures/sample-data.yaml
+++ b/tests/fixtures/sample-data.yaml
@@ -17,6 +17,7 @@ analyses:
     user: paul.anderson@magnolia.com
     progress: .54
     data_analysis: MIP-DNA
+    ticket: 123456
 
   - family: nicemice
     version: v3.5.0

--- a/tests/fixtures/sample-data.yaml
+++ b/tests/fixtures/sample-data.yaml
@@ -17,7 +17,7 @@ analyses:
     user: paul.anderson@magnolia.com
     progress: .54
     data_analysis: MIP-DNA
-    ticket: 123456
+    ticket_id: 123456
 
   - family: nicemice
     version: v3.5.0

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -241,6 +241,7 @@ def post_add_pending_analysis():
             out_dir=content.get("out_dir"),
             priority=content.get("priority"),
             data_analysis=content.get("data_analysis"),
+            ticket=content.get("ticket"),
         )
         data = stringify_timestamps(analysis_obj.to_dict())
         return jsonify(**data), 201

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -241,7 +241,7 @@ def post_add_pending_analysis():
             out_dir=content.get("out_dir"),
             priority=content.get("priority"),
             data_analysis=content.get("data_analysis"),
-            ticket=content.get("ticket"),
+            ticket_id=content.get("ticket"),
         )
         data = stringify_timestamps(analysis_obj.to_dict())
         return jsonify(**data), 201

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -169,6 +169,7 @@ class BaseHandler:
         priority: str,
         email: str = None,
         data_analysis: str = None,
+        ticket: str = None,
     ) -> models.Analysis:
         """Add pending entry for an analysis."""
         started_at = dt.datetime.now()
@@ -181,6 +182,7 @@ class BaseHandler:
             out_dir=out_dir,
             priority=priority,
             data_analysis=data_analysis,
+            ticket=ticket,
         )
         new_log.user = self.user(email) if email else None
         self.add_commit(new_log)

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -169,7 +169,7 @@ class BaseHandler:
         priority: str,
         email: str = None,
         data_analysis: str = None,
-        ticket: str = None,
+        ticket_id: str = None,
     ) -> models.Analysis:
         """Add pending entry for an analysis."""
         started_at = dt.datetime.now()
@@ -182,7 +182,7 @@ class BaseHandler:
             out_dir=out_dir,
             priority=priority,
             data_analysis=data_analysis,
-            ticket=ticket,
+            ticket_id=ticket_id,
         )
         new_log.user = self.user(email) if email else None
         self.add_commit(new_log)

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -73,6 +73,7 @@ class Analysis(Model):
     user_id = Column(ForeignKey(User.id))
     progress = Column(types.Float, default=0.0)
     data_analysis = Column(types.String(32))
+    ticket = Column(types.String(32))
 
     failed_jobs = orm.relationship("Job", backref="analysis")
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -73,7 +73,7 @@ class Analysis(Model):
     user_id = Column(ForeignKey(User.id))
     progress = Column(types.Float, default=0.0)
     data_analysis = Column(types.String(32))
-    ticket = Column(types.String(32))
+    ticket_id = Column(types.String(32))
 
     failed_jobs = orm.relationship("Job", backref="analysis")
 


### PR DESCRIPTION
This PR adds ticket information for analysis. This will make it possible to sort the cigrid main analyses view by ticket number, which in turn will make it easier for production to deliver all analysis that belongs to one ticket.
 

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
