### PR TITLE
fix(workflows) Specify old version of ubuntu for the workflow runners

### DIFF
--- a/.github/workflows/production_install_clinical-db.yml
+++ b/.github/workflows/production_install_clinical-db.yml
@@ -6,7 +6,7 @@ jobs:
 
   production-install:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/.github/workflows/production_install_hasta.yml
+++ b/.github/workflows/production_install_hasta.yml
@@ -6,7 +6,7 @@ jobs:
 
   production-install:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
 


### PR DESCRIPTION
## Description
The `TB production install clinical-db / production-install` and `TB production install hasta / production-install` are currently failing for all PRs. This is due to an update to the `ubuntu-latest` runner used in the two workflows ([see here](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/)) 

As suggested in the blog post this PR switches to using `ubuntu-20.04` instead.
### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
