### PR TITLE
Adding set-status and add-comment endpoints to TB

### DIFF
--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -116,6 +116,17 @@ def test_set_analysis_uploaded(sample_store, timestamp_now: datetime):
     # THEN the column uploaded_at should be updated
     assert analysis_obj.uploaded_at == uploaded_at
 
+def test_set_analysis_failed(sample_store):
+    """Test setting analysis to failed for an analysis."""
+
+    # GIVEN a store with an analysis
+    analysis_obj: models.Analysis = sample_store.analyses().first()
+
+    # WHEN setting analysis to failed
+    sample_store.set_analysis_failed(case_id=analysis_obj.family, status="failed")
+
+    # THEN the column status should be updated with failed.
+    assert analysis_obj.status == "failed"
 
 @pytest.mark.parametrize(
     "family, expected_bool",

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -116,6 +116,7 @@ def test_set_analysis_uploaded(sample_store, timestamp_now: datetime):
     # THEN the column uploaded_at should be updated
     assert analysis_obj.uploaded_at == uploaded_at
 
+
 def test_set_analysis_failed(sample_store):
     """Test setting analysis to failed for an analysis."""
 
@@ -127,6 +128,7 @@ def test_set_analysis_failed(sample_store):
 
     # THEN the column status should be updated with failed.
     assert analysis_obj.status == "failed"
+
 
 @pytest.mark.parametrize(
     "family, expected_bool",

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -3,7 +3,7 @@ import datetime
 
 import pytest
 
-from trailblazer.store import models
+from trailblazer.store.models import Analysis
 
 
 def test_setup_and_info(store):
@@ -107,7 +107,7 @@ def test_set_analysis_uploaded(sample_store, timestamp_now: datetime):
     """Test setting analysis uploaded at for an analysis."""
 
     # GIVEN a store with an analysis
-    analysis_obj: models.Analysis = sample_store.analyses().first()
+    analysis_obj: Analysis = sample_store.analyses().first()
     uploaded_at: datetime = timestamp_now
 
     # WHEN setting an analysis uploaded at

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -124,7 +124,7 @@ def test_set_analysis_failed(sample_store):
     analysis_obj: models.Analysis = sample_store.analyses().first()
 
     # WHEN setting analysis to failed
-    sample_store.set_analysis_failed(case_id=analysis_obj.family, status="failed")
+    sample_store.set_analysis_status(case_id=analysis_obj.family, status="failed")
 
     # THEN the column status should be updated with failed.
     assert analysis_obj.status == "failed"

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -130,6 +130,20 @@ def test_set_analysis_failed(sample_store):
     assert analysis_obj.status == "failed"
 
 
+def test_add_comment(sample_store):
+    """Test adding comment to an analysis object."""
+
+    # GIVEN a store with an analysus
+    analysis_obj: models.Analysis = sample_store.analyses().first()
+    comment: str = "test comment"
+
+    # WHEN adding a comment
+    sample_store.add_comment(case_id=analysis_obj.family, comment=comment)
+
+    # THEN a comment should have been added
+    assert analysis_obj.comment == comment
+
+
 @pytest.mark.parametrize(
     "family, expected_bool",
     [

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -121,7 +121,7 @@ def test_set_analysis_failed(sample_store):
     """Test setting analysis to failed for an analysis."""
 
     # GIVEN a store with an analysis
-    analysis_obj: models.Analysis = sample_store.analyses().first()
+    analysis_obj: Analysis = sample_store.analyses().first()
 
     # WHEN setting analysis to failed
     sample_store.set_analysis_status(case_id=analysis_obj.family, status="failed")
@@ -133,8 +133,8 @@ def test_set_analysis_failed(sample_store):
 def test_add_comment(sample_store):
     """Test adding comment to an analysis object."""
 
-    # GIVEN a store with an analysus
-    analysis_obj: models.Analysis = sample_store.analyses().first()
+    # GIVEN a store with an analysis
+    analysis_obj: Analysis = sample_store.analyses().first()
     comment: str = "test comment"
 
     # WHEN adding a comment

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -261,14 +261,13 @@ def put_set_analysis_uploaded():
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409
 
+
 @blueprint.route("/set-analysis-failed", methods=["PUT"])
 def put_set_analysis_failed():
     content: Response.json = request.json
 
     try:
-        store.set_analysis_failed(
-            case_id=content.get("case_id"), status=content.get("status")
-        )
+        store.set_analysis_failed(case_id=content.get("case_id"), status=content.get("status"))
         return jsonify("Success! Update request sent"), 201
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -257,7 +257,7 @@ def put_set_analysis_uploaded():
         store.set_analysis_uploaded(
             case_id=content.get("case_id"), uploaded_at=content.get("uploaded_at")
         )
-        return jsonify("Success! Update request sent"), 201
+        return jsonify("Success! Uploaded at request sent"), 201
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409
 
@@ -268,6 +268,6 @@ def put_set_analysis_failed():
 
     try:
         store.set_analysis_failed(case_id=content.get("case_id"), status=content.get("status"))
-        return jsonify("Success! Update request sent"), 201
+        return jsonify("Success! Analysis set to fail request sent"), 201
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -271,3 +271,14 @@ def put_set_analysis_status():
         return jsonify("Success! Analysis set to fail request sent"), 201
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409
+
+
+@blueprint.route("/add-comment", methods=["PUT"])
+def put_add_comment():
+    content: Response.json = request.json
+
+    try:
+        store
+        return jsonify("Success! Adding comment request sent"), 201
+    except Exception as error:
+        return jsonify(f"Exception: {error}"), 409

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -268,7 +268,7 @@ def put_set_analysis_status():
 
     try:
         store.set_analysis_status(case_id=content.get("case_id"), status=content.get("status"))
-        return jsonify("Success! Analysis set to fail request sent"), 201
+        return jsonify(f"Success! Analysis set to {content.get('status')} request sent"), 201
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409
 

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -260,3 +260,15 @@ def put_set_analysis_uploaded():
         return jsonify("Success! Update request sent"), 201
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409
+
+@blueprint.route("/set-analysis-failed", methods=["PUT"])
+def put_set_analysis_failed():
+    content: Response.json = request.json
+
+    try:
+        store.set_analysis_failed(
+            case_id=content.get("case_id"), status=content.get("status")
+        )
+        return jsonify("Success! Update request sent"), 201
+    except Exception as error:
+        return jsonify(f"Exception: {error}"), 409

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -278,7 +278,7 @@ def put_add_comment():
     content: Response.json = request.json
 
     try:
-        store
+        store.add_comment(case_id=content.get("case_id"), comment=content.get("comment"))
         return jsonify("Success! Adding comment request sent"), 201
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -262,12 +262,12 @@ def put_set_analysis_uploaded():
         return jsonify(f"Exception: {error}"), 409
 
 
-@blueprint.route("/set-analysis-failed", methods=["PUT"])
-def put_set_analysis_failed():
+@blueprint.route("/set-analysis-status", methods=["PUT"])
+def put_set_analysis_status():
     content: Response.json = request.json
 
     try:
-        store.set_analysis_failed(case_id=content.get("case_id"), status=content.get("status"))
+        store.set_analysis_status(case_id=content.get("case_id"), status=content.get("status"))
         return jsonify("Success! Analysis set to fail request sent"), 201
     except Exception as error:
         return jsonify(f"Exception: {error}"), 409

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -264,9 +264,11 @@ class BaseHandler:
 
     def add_comment(self, case_id: str, comment: str):
         analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.comment: str = comment + analysis_obj.comment if analysis_obj.comment else ""
-
+        analysis_obj.comment: str = (
+            " ".join([analysis_obj.comment, comment]) if analysis_obj.comment else comment
+        )
         self.commit()
+
         LOG.info(f"Adding comment {comment} to analysis {analysis_obj.family}")
 
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -257,14 +257,14 @@ class BaseHandler:
 
     def set_analysis_status(self, case_id: str, status: str):
         """Setting analysis status to failed."""
-        analysis_obj: models.Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.status = status
+        analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
+        analysis_obj.status: str = status
         self.commit()
         LOG.info(f"{analysis_obj.family} - Status set to failed")
 
     def add_comment(self, case_id: str, comment: str):
-        analysis_obj: models.Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.comment = comment
+        analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
+        analysis_obj.comment: str = comment
         self.commit()
         LOG.info(f"Adding comment {comment} to analysis {analysis_obj.family}")
 

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -256,15 +256,16 @@ class BaseHandler:
         self.commit()
 
     def set_analysis_status(self, case_id: str, status: str):
-        """Setting analysis status to failed."""
+        """Setting analysis status."""
         analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
         analysis_obj.status: str = status
         self.commit()
-        LOG.info(f"{analysis_obj.family} - Status set to failed")
+        LOG.info(f"{analysis_obj.family} - Status set to {status}")
 
     def add_comment(self, case_id: str, comment: str):
         analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.comment: str = comment
+        analysis_obj.comment: str = analysis_obj.comment if analysis_obj.comment else "" + comment
+
         self.commit()
         LOG.info(f"Adding comment {comment} to analysis {analysis_obj.family}")
 

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -255,7 +255,6 @@ class BaseHandler:
         self.commit()
         LOG.info(f"{analysis_obj.family} - uploaded at set to {uploaded_at}")
 
-
     def set_analysis_failed(self, case_id: str, status: str):
         """Setting analysis status to failed."""
         analysis_obj: models.Analysis = self.get_latest_analysis(case_id=case_id)

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -262,6 +262,12 @@ class BaseHandler:
         self.commit()
         LOG.info(f"{analysis_obj.family} - Status set to failed")
 
+    def add_comment(self, case_id: str, comment: str):
+        analysis_obj: models.Analysis = self.get_latest_analysis(case_id=case_id)
+        analysis_obj.comment = comment
+        self.commit()
+        LOG.info(f"Adding comment {comment} to analysis {analysis_obj.family}")
+
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:
         """Delete the analysis output."""
         analysis_obj = self.analysis(analysis_id=analysis_id)

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -255,6 +255,14 @@ class BaseHandler:
         self.commit()
         LOG.info(f"{analysis_obj.family} - uploaded at set to {uploaded_at}")
 
+
+    def set_analysis_failed(self, case_id: str, status: str):
+        """Setting analysis status to failed."""
+        analysis_obj: models.Analysis = self.get_latest_analysis(case_id=case_id)
+        analysis_obj.status = status
+        self.commit()
+        LOG.info(f"{analysis_obj.family} - Status set to failed")
+
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:
         """Delete the analysis output."""
         analysis_obj = self.analysis(analysis_id=analysis_id)

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -255,7 +255,7 @@ class BaseHandler:
         self.commit()
         LOG.info(f"{analysis_obj.family} - uploaded at set to {uploaded_at}")
 
-    def set_analysis_failed(self, case_id: str, status: str):
+    def set_analysis_status(self, case_id: str, status: str):
         """Setting analysis status to failed."""
         analysis_obj: models.Analysis = self.get_latest_analysis(case_id=case_id)
         analysis_obj.status = status

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -22,6 +22,7 @@ from trailblazer.constants import (
 )
 from trailblazer.exc import EmptySqueueError, TrailblazerError
 from trailblazer.store import models
+from trailblazer.store.models import Analysis
 from trailblazer.store.utils import formatters
 
 LOG = logging.getLogger(__name__)
@@ -250,10 +251,9 @@ class BaseHandler:
 
     def set_analysis_uploaded(self, case_id: str, uploaded_at: dt.datetime) -> None:
         """Setting analysis uploaded at."""
-        analysis_obj: models.Analysis = self.get_latest_analysis(case_id=case_id)
+        analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
         analysis_obj.uploaded_at: dt.datetime = uploaded_at
         self.commit()
-        LOG.info(f"{analysis_obj.family} - uploaded at set to {uploaded_at}")
 
     def set_analysis_status(self, case_id: str, status: str):
         """Setting analysis status to failed."""

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -264,7 +264,7 @@ class BaseHandler:
 
     def add_comment(self, case_id: str, comment: str):
         analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.comment: str = analysis_obj.comment if analysis_obj.comment else "" + comment
+        analysis_obj.comment: str = comment + analysis_obj.comment if analysis_obj.comment else ""
 
         self.commit()
         LOG.info(f"Adding comment {comment} to analysis {analysis_obj.family}")

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -264,9 +264,8 @@ class BaseHandler:
 
     def add_comment(self, case_id: str, comment: str):
         analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.comment: str = (
-            " ".join([analysis_obj.comment, comment]) if analysis_obj.comment else comment
-        )
+        analysis_obj.comment: str = " ".join([analysis_obj.comment, comment]) if analysis_obj.comment else comment
+
         self.commit()
 
         LOG.info(f"Adding comment {comment} to analysis {analysis_obj.family}")

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -264,7 +264,9 @@ class BaseHandler:
 
     def add_comment(self, case_id: str, comment: str):
         analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.comment: str = " ".join([analysis_obj.comment, comment]) if analysis_obj.comment else comment
+        analysis_obj.comment: str = (
+            " ".join([analysis_obj.comment, comment]) if analysis_obj.comment else comment
+        )
 
         self.commit()
 


### PR DESCRIPTION
This PR adds/fixes ...

This PR adds a function to the TB API to set an analysis to failed. This is needed in the microsalt QC as if the QC fails we want to set the analysis to fail.

It also adds an "add_comment" endpoint so that a comment can be added to an analysis through the API

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t trailblazer -b set-analysis-to-fail -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
