### PR TITLE
fix(TowerWorkflow): avoid zero division

### DIFF
--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -183,7 +183,7 @@ class TowerAPI:
         processes to be run is unknown."""
         if self.is_complete:
             return 100
-        elif self.is_pending:
+        elif self.is_pending or self.total_jobs == 0:
             return 0
         else:
             return int(self.succeeded_jobs * 100.0 / self.total_jobs)


### PR DESCRIPTION
## Description

### Fixed

- Avoid ZeroDivisionError by setting progress to 0 when total jobs is 0 

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] activate stage: `us`
- [x] request trailblazer-stage on hasta: `paxa`
- [x] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b fix_zerodivision -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] Run `trailblazer scan` with a cancelled tower job that was not started. 

### Expected test outcome
- [x] It should not rise `ZeroDivisionError` but instead it should output `Updated status <CASE_ID> - <TB_ID>: canceled`

## Review
- [x] tests executed by EFC
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
