### PR TITLE
fix(TowerWorkflow): progress as fraction

### DIFF
--- a/tests/apps/tower/test_tower_api.py
+++ b/tests/apps/tower/test_tower_api.py
@@ -93,11 +93,11 @@ def test_tower_api_succeeded_jobs(
     "response_file, expected_progress",
     [
         (TowerResponseFile.PENDING, 0),
-        (TowerResponseFile.RUNNING, 15),
-        (TowerResponseFile.COMPLETED, 100),
+        (TowerResponseFile.RUNNING, 0.15),
+        (TowerResponseFile.COMPLETED, 1),
     ],
 )
-def test_tower_api_progress(tower_id: str, response_file: Path, expected_progress: int) -> None:
+def test_tower_api_progress(tower_id: str, response_file: Path, expected_progress: float) -> None:
     """Assess that TowerAPI returns the progress percentage given a response."""
 
     # GIVEN an tower_api with a mock query response

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -280,9 +280,9 @@ def test_update_tower_jobs(sample_store: MockStore, tower_jobs: List[dict], case
 @pytest.mark.parametrize(
     "case_id, status, progress",
     [
-        (CaseIDs.RUNNING, TrailblazerStatus.RUNNING.value, 15),
+        (CaseIDs.RUNNING, TrailblazerStatus.RUNNING.value, 0.15),
         (CaseIDs.PENDING, TrailblazerStatus.PENDING.value, 0),
-        (CaseIDs.COMPLETED, TrailblazerStatus.COMPLETED.value, 100),
+        (CaseIDs.COMPLETED, TrailblazerStatus.COMPLETED.value, 1),
     ],
 )
 def test_update_tower_run_status(sample_store: MockStore, case_id: str, status: str, progress: int):

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -177,7 +177,7 @@ class TowerAPI:
         return sum(process.is_complete for process in self.processes)
 
     @property
-    def progress(self) -> int:
+    def progress(self) -> float:
         """Returns the progress fraction of a workflow.
         Note this number is not accurate since that exact number of
         processes to be run is unknown."""
@@ -186,7 +186,7 @@ class TowerAPI:
         elif self.is_pending or self.total_jobs == 0:
             return 0
         else:
-            return int(self.succeeded_jobs / self.total_jobs)
+            return round(float(self.succeeded_jobs) / self.total_jobs, 2)
 
     def get_jobs(self, analysis_id: int) -> List[dict]:
         """Returns a list of jobs associated to a workflow."""

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -178,15 +178,15 @@ class TowerAPI:
 
     @property
     def progress(self) -> int:
-        """Returns the progress percentage of a workflow.
+        """Returns the progress fraction of a workflow.
         Note this number is not accurate since that exact number of
         processes to be run is unknown."""
         if self.is_complete:
-            return 100
+            return 1
         elif self.is_pending or self.total_jobs == 0:
             return 0
         else:
-            return int(self.succeeded_jobs * 100.0 / self.total_jobs)
+            return int(self.succeeded_jobs / self.total_jobs)
 
     def get_jobs(self, analysis_id: int) -> List[dict]:
         """Returns a list of jobs associated to a workflow."""


### PR DESCRIPTION
## Description

### Fixed

- Return progress as fraction instead of percentage for proper rendering in cigrid and to be consistent with slurm progress. 

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
