### PR TITLE
Add QC as status

### DIFF
--- a/alembic/versions/8a693bb99de3_add_qc_as_status.py
+++ b/alembic/versions/8a693bb99de3_add_qc_as_status.py
@@ -1,0 +1,38 @@
+"""add qc as status
+
+Revision ID: 8a693bb99de3
+Revises: d1183a4d6d27
+Create Date: 2023-05-03 10:55:35.883947
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "8a693bb99de3"
+down_revision = "d1183a4d6d27"
+branch_labels = None
+depends_on = None
+
+from sqlalchemy import types
+
+from alembic import op
+
+OLD_OPTIONS = ("pending", "running", "completed", "failed", "error", "canceled", "completing")
+NEW_OPTIONS = ("pending", "running", "completed", "failed", "error", "canceled", "completing", "qc")
+
+
+def upgrade():
+    op.alter_column(
+        "analysis",
+        "status",
+        existing_type=types.Enum(*OLD_OPTIONS),
+        type_=types.Enum(*NEW_OPTIONS),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "analysis",
+        "status",
+        existing_type=types.Enum(*NEW_OPTIONS),
+        type_=types.Enum(*OLD_OPTIONS),
+    )

--- a/tests/apps/tower/test_tower_api.py
+++ b/tests/apps/tower/test_tower_api.py
@@ -50,7 +50,7 @@ def test_tower_api_is_pending(tower_id: str, response_file: Path, expected_bool:
 @pytest.mark.parametrize(
     "response_file, expected_nr_total_jobs",
     [
-        # (TowerResponseFile.PENDING, 0),
+        (TowerResponseFile.PENDING, 0),
         (TowerResponseFile.RUNNING, 13),
         (TowerResponseFile.COMPLETED, 13),
     ],

--- a/tests/apps/tower/test_tower_api.py
+++ b/tests/apps/tower/test_tower_api.py
@@ -14,7 +14,7 @@ from trailblazer.constants import TrailblazerStatus
     [
         (TowerResponseFile.PENDING, TrailblazerStatus.PENDING.value),
         (TowerResponseFile.RUNNING, TrailblazerStatus.RUNNING.value),
-        (TowerResponseFile.COMPLETED, TrailblazerStatus.COMPLETED.value),
+        (TowerResponseFile.COMPLETED, TrailblazerStatus.QC.value),
     ],
 )
 def test_tower_api_status(tower_id: str, response_file: Path, expected_status: str) -> None:

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -282,7 +282,7 @@ def test_update_tower_jobs(sample_store: MockStore, tower_jobs: List[dict], case
     [
         (CaseIDs.RUNNING, TrailblazerStatus.RUNNING.value, 0.15),
         (CaseIDs.PENDING, TrailblazerStatus.PENDING.value, 0),
-        (CaseIDs.COMPLETED, TrailblazerStatus.COMPLETED.value, 1),
+        (CaseIDs.COMPLETED, TrailblazerStatus.QC.value, 1),
     ],
 )
 def test_update_tower_run_status(sample_store: MockStore, case_id: str, status: str, progress: int):

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -155,7 +155,7 @@ class TowerAPI:
     @property
     def is_complete(self) -> bool:
         """Returns True if workflow has completed. Otherwise returns False."""
-        return self.status == TrailblazerStatus.COMPLETED.value
+        return self.status == TrailblazerStatus.QC.value
 
     @property
     def processes(self) -> List[TowerProcess]:

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -140,7 +140,7 @@ class TowerAPI:
     @property
     def status(self) -> str:
         """Returns the status of an analysis (also called workflow in NF Tower)."""
-        status = TOWER_STATUS.get(self.response.workflow.status, TrailblazerStatus.ERROR.value)
+        status: str = TOWER_STATUS.get(self.response.workflow.status, TrailblazerStatus.ERROR.value)
 
         # If the whole workflow (analysis) is completed set it as QC instead of COMPLETE
         if status == TrailblazerStatus.COMPLETED.value:

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -140,7 +140,12 @@ class TowerAPI:
     @property
     def status(self) -> str:
         """Returns the status of an analysis (also called workflow in NF Tower)."""
-        return TOWER_STATUS.get(self.response.workflow.status, TrailblazerStatus.ERROR.value)
+        status = TOWER_STATUS.get(self.response.workflow.status, TrailblazerStatus.ERROR.value)
+
+        # If the whole workflow (analysis) is completed set it as QC instead of COMPLETE
+        if status == TrailblazerStatus.COMPLETED.value:
+            return TrailblazerStatus.QC.value
+        return status
 
     @property
     def is_pending(self) -> bool:

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -8,8 +8,6 @@ STARTED_STATUSES = ["completed", "failed", "pending", "running", "error", "compl
 SLURM_NORMAL_CATEGORIES = ("completed", "running", "pending", "completing")
 SLURM_FAILED_CATEGORIES = ("failed", "cancelled", "timeout")
 SLURM_ACTIVE_CATEGORIES = ("running", "pending", "completing")
-
-STATUS_OPTIONS = ("pending", "running", "completed", "failed", "error", "canceled", "completing")
 JOB_STATUS_OPTIONS = SLURM_NORMAL_CATEGORIES + SLURM_FAILED_CATEGORIES
 PRIORITY_OPTIONS = ("low", "normal", "high", "express", "maintenance")
 TYPES = ("other", "rna", "tgs", "wes", "wgs", "wts")
@@ -36,6 +34,11 @@ class TrailblazerStatus(Enum):
     ERROR: str = "error"
     CANCELLED: str = "canceled"
     COMPLETING: str = "completing"
+    QC: str = "qc"
+
+    @classmethod
+    def list(cls):
+        return [status.value for status in cls]
 
 
 TOWER_STATUS: Dict[str, str] = {
@@ -60,3 +63,5 @@ TOWER_PROCESS_STATUS: Dict[str, str] = {
 
 TOWER_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 TOWER_TIMESTAMP_FORMAT_ALTERNATIVE = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+STATUS_OPTIONS = tuple(TrailblazerStatus.list())


### PR DESCRIPTION
## Description


### Added

- Adds QC as status

### Changed

- If a tower workflow (full analysis) is completed set the status to QC. This allows to perform post-analysis QC steps without triggering actions by marking as complete.



### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b tw_commplete_as_qc -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh tw_commplete_as_qc`

### How to test
- [x] `trailblazer scan`. Make sure that analyses that are completed are set as qc:

<img width="310" alt="image" src="https://user-images.githubusercontent.com/29628428/235906111-ac03e43c-f207-47d0-919d-55bf913c1731.png">

<img width="639" alt="image" src="https://user-images.githubusercontent.com/29628428/235907467-455804cb-cde5-4be9-ac34-7b3156bbe178.png">

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
