### PR TITLE
feat(python): Update to version 3.8

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - uses: psf/black@stable
         with:
           options: ". --check --line-length 100"

--- a/.github/workflows/production_install.yml
+++ b/.github/workflows/production_install.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.7
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Test install
       run: |

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -16,7 +16,7 @@ jobs:
    - name: Set up Python
      uses: actions/setup-python@v4
      with:
-      python-version: 3.7
+      python-version: 3.8
 
    - name: Install build tools
      run: >-

--- a/.github/workflows/test_and_coverage.yml
+++ b/.github/workflows/test_and_coverage.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install Trailblazer
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_TREADS=1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Trailblazer is a tool that aims to provide:
 
 ## Installation
 
-Trailblazer is written in Python 3.7+ and is available on the [Python Package Index][pypi] (PyPI).
+Trailblazer is written in Python 3.8 and is available on the [Python Package Index][pypi] (PyPI).
 
 ```bash
 pip install trailblazer

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Environment :: Console",
     ],
 )


### PR DESCRIPTION
## Description

Python 3.7 has reached end-of-life. Trailblazer should now run on python 3.8.

### Changed

- Python version to 3.8


### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b update_pythonn -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh `

### How to test
- [x] See below

### Expected test outcome
- [x] See below
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] tests executed by HS
- [x] "Merge and deploy" approved by @seallard 
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
