### PR TITLE
Pin base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.8-slim@sha256:7bebae21c28738810809ac96734e7a423e6e1e20ebeb6a419e4ddc3f2827ab7b
+FROM docker.io/library/python:3.8-slim-bullseye
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_TREADS=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.8-slim-bullseye
+FROM python:3.8-slim-bullseye
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_TREADS=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM docker.io/library/python:3.8-slim@sha256:7bebae21c28738810809ac96734e7a423e6e1e20ebeb6a419e4ddc3f2827ab7b
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_TREADS=1


### PR DESCRIPTION
The latest tag was broken for the base image used. Switching to bullseye instead.

## Description
This PR changes the Docker base image to python-bullseye-slim See https://github.com/docker-library/python/issues/835.

### Fixed
- Change broken docker base image to bullseye

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
