### PR TITLE
fix(TowerWorkflow) null status returned when job is cached 

### DIFF
--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -56,6 +56,7 @@ TOWER_STATUS: Dict[str, str] = {
     "SUBMITTED": TrailblazerStatus.PENDING.value,
     "RUNNING": TrailblazerStatus.RUNNING.value,
     "SUCCEEDED": TrailblazerStatus.COMPLETED.value,
+    "CACHED": TrailblazerStatus.COMPLETED.value,
     "FAILED": TrailblazerStatus.FAILED.value,
     "CANCELLED": TrailblazerStatus.CANCELLED.value,
     "COMPLETED": TrailblazerStatus.COMPLETED.value,

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -53,15 +53,15 @@ class TrailblazerStatus(Enum):
 
 
 TOWER_STATUS: Dict[str, str] = {
-    "NEW": TrailblazerStatus.PENDING.value,
-    "SUBMITTED": TrailblazerStatus.PENDING.value,
-    "RUNNING": TrailblazerStatus.RUNNING.value,
-    "SUCCEEDED": TrailblazerStatus.COMPLETED.value,
-    "COMPLETED": TrailblazerStatus.COMPLETED.value,
+    "ABORTED": TrailblazerStatus.CANCELLED.value,
     "CACHED": TrailblazerStatus.COMPLETED.value,
     "CANCELLED": TrailblazerStatus.CANCELLED.value,
-    "ABORTED": TrailblazerStatus.CANCELLED.value,
+    "COMPLETED": TrailblazerStatus.COMPLETED.value,
     "FAILED": TrailblazerStatus.FAILED.value,
+    "NEW": TrailblazerStatus.PENDING.value,
+    "RUNNING": TrailblazerStatus.RUNNING.value,
+    "SUBMITTED": TrailblazerStatus.PENDING.value,
+    "SUCCEEDED": TrailblazerStatus.COMPLETED.value,
     "UNKNOWN": TrailblazerStatus.FAILED.value,
 }
 

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -53,13 +53,15 @@ class TrailblazerStatus(Enum):
 
 
 TOWER_STATUS: Dict[str, str] = {
+    "NEW": TrailblazerStatus.PENDING.value,
     "SUBMITTED": TrailblazerStatus.PENDING.value,
     "RUNNING": TrailblazerStatus.RUNNING.value,
     "SUCCEEDED": TrailblazerStatus.COMPLETED.value,
-    "CACHED": TrailblazerStatus.COMPLETED.value,
-    "FAILED": TrailblazerStatus.FAILED.value,
-    "CANCELLED": TrailblazerStatus.CANCELLED.value,
     "COMPLETED": TrailblazerStatus.COMPLETED.value,
+    "CACHED": TrailblazerStatus.COMPLETED.value,
+    "CANCELLED": TrailblazerStatus.CANCELLED.value,
+    "ABORTED": TrailblazerStatus.CANCELLED.value,
+    "FAILED": TrailblazerStatus.FAILED.value,
     "UNKNOWN": TrailblazerStatus.FAILED.value,
 }
 


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/trailblazer/issues/235

### Fixed

- Null status returned when job has been cached in TowerWorkflow

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] activate stage: `us`
- [x] request trailblazer-stage on hasta: `paxa`
- [x] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b fix_status_null -a
    ```

### How to test
- [x] Resume a case with tasks that have previously completed and can be resumed: `cg workflow rnafusion run case_id`
- [x] Make sure that the run started in tower and tasks are marked as cached in tower. Then run `trailblazer scan` with the master cg branch.
- [x] Check the trailblazer database (job table), filter for that analysis. Check that the status of the cached tasks is null.
- [x] Check the case on cigrid. Cached jobs are missing from the case view. 
- [x] Install this branch on stage and repeat `trailblazer scan`
- [x] Check the trailblazer database (job table), filter for that analysis. Check that the status of the cached tasks is `completed`.
- [x] Check the case on cigrid. Cached jobs appear as `COMPLETED` in the case view. 


## Review
- [x] tests executed by EFC
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
