### PR TITLE
quick fix: unsupported tower status in job table

### DIFF
--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -53,9 +53,9 @@ class TrailblazerStatus(Enum):
 
 
 TOWER_STATUS: Dict[str, str] = {
-    "ABORTED": TrailblazerStatus.CANCELLED.value,
+    "ABORTED": TrailblazerStatus.FAILED.value,
     "CACHED": TrailblazerStatus.COMPLETED.value,
-    "CANCELLED": TrailblazerStatus.CANCELLED.value,
+    "CANCELLED": TrailblazerStatus.FAILED.value,
     "COMPLETED": TrailblazerStatus.COMPLETED.value,
     "FAILED": TrailblazerStatus.FAILED.value,
     "NEW": TrailblazerStatus.PENDING.value,


### PR DESCRIPTION
## Description

Quick fix and related to https://github.com/Clinical-Genomics/trailblazer/issues/239

### Fixed

- `Canceled` or `aborted` tower status will be temporarily be set as `failed`

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] activate stage: `us`
- [x] request trailblazer-stage on hasta: `paxa`
- [x] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b quick_fix_tw_status -a
    ```

### How to test
- [x] On the master branch. Start an rnafusion case.  Do `trailblazer scan`. Wait until a task is running and cancel it on slurm with `scancel jobid`. Do `trailblazer scan` again. 
- [x] Refresh cigrid-trailblazer and verify it's not working. Go to the database and verify that the status of the rule you canceled is set as `canceled` in the job table.
- [x] Modify databases to a functional state by removing the jobs of the case in the job table and updating the status of the case to `pending` in the analysis table
- [x] Change to this branch.  Do `trailblazer scan`. 
- [x] Refresh cigrid-trailblazer and verify it's working now. Verify that the case is set as `failed`. Go to the database and verify that the status of the canceled rule is set as `failed` in the job table.

<img width="1359" alt="image" src="https://github.com/Clinical-Genomics/trailblazer/assets/29628428/65ee88f2-9f6a-47db-b7c2-94f951d3b7a8">

<img width="1223" alt="image" src="https://github.com/Clinical-Genomics/trailblazer/assets/29628428/095b077c-4a02-4255-9788-e28c510bb5b7">



## Review
- [ ] tests executed by EFC
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
