### PR TITLE
Cancel tower workflow

### DIFF
--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -5,8 +5,8 @@ import pytest
 import trailblazer
 from tests.mocks.store_mock import MockStore
 from trailblazer.cli.core import (
-    archive_user,
     add_user_to_db,
+    archive_user,
     base,
     cancel,
     delete,
@@ -18,6 +18,8 @@ from trailblazer.cli.core import (
     set_analysis_status,
     unarchive_user,
 )
+from trailblazer.constants import TrailblazerStatus
+from trailblazer.store.models import Analysis
 
 
 def test_base(cli_runner):
@@ -126,19 +128,19 @@ def test_cancel_not_running(cli_runner, trailblazer_context, caplog):
         assert "is not running" in caplog.text
 
 
-def test_cancel_ongoing(cli_runner, trailblazer_context, caplog):
+def test_cancel_ongoing_slurm_analysis(cli_runner, trailblazer_context, caplog):
     with caplog.at_level("INFO"):
         # GIVEN an analysis that is running
         trailblazer_context["trailblazer"].update_ongoing_analyses()
-        analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(
+        analysis: Analysis = trailblazer_context["trailblazer"].get_latest_analysis(
             case_id="blazinginsect"
         )
 
         # Analysis should have jobs that can be cancelled
-        assert analysis_obj.failed_jobs
+        assert analysis.failed_jobs
 
         # WHEN running cancel command
-        result = cli_runner.invoke(cancel, [str(analysis_obj.id)], obj=trailblazer_context)
+        result = cli_runner.invoke(cancel, [str(analysis.id)], obj=trailblazer_context)
 
         # THEN command should run successfully
         assert result.exit_code == 0
@@ -151,8 +153,37 @@ def test_cancel_ongoing(cli_runner, trailblazer_context, caplog):
         assert "690988" in caplog.text
 
         # THEN analysis status is set to cancelled
-        assert "cancelled" in analysis_obj.comment
-        assert analysis_obj.status == "canceled"
+        assert "cancelled" in analysis.comment
+        assert analysis.status == TrailblazerStatus.CANCELLED
+
+
+def test_cancel_ongoing_tower_analysis(cli_runner, trailblazer_context, caplog):
+    with caplog.at_level("INFO"):
+        # GIVEN an analysis that is running
+        trailblazer_context["trailblazer"].update_ongoing_analyses()
+        analysis: Analysis = trailblazer_context["trailblazer"].get_latest_analysis(
+            case_id="cuddlyhen"
+        )
+
+        # Analysis should have jobs that can be cancelled
+        assert analysis.failed_jobs
+
+        # WHEN running cancel command
+        result = cli_runner.invoke(cancel, [str(analysis.id)], obj=trailblazer_context)
+
+        # THEN command should run successfully
+        assert result.exit_code == 0
+
+        # THEN log should inform of successful cancellation
+        assert "all ongoing jobs cancelled successfully" in caplog.text
+        assert "Cancelling" in caplog.text
+
+        # THEN job id from squeue output will be cancelled
+        # assert "690988" in caplog.text
+
+        # THEN analysis status is set to cancelled
+        assert "cancelled" in analysis.comment
+        assert analysis.status == TrailblazerStatus.CANCELLED
 
 
 def test_delete_nonexisting(cli_runner, trailblazer_context, caplog):

--- a/tests/mocks/store_mock.py
+++ b/tests/mocks/store_mock.py
@@ -3,6 +3,7 @@ import subprocess
 from tests.apps.tower.conftest import TOWER_ID, CaseIDs, TowerResponseFile, TowerTaskResponseFile
 from tests.mocks.tower_mock import MockTowerAPI
 from trailblazer.store.api import Store
+from trailblazer.store.models import Analysis
 
 
 class MockStore(Store):
@@ -29,6 +30,12 @@ class MockStore(Store):
 
     @staticmethod
     def cancel_slurm_job(slurm_id: int, ssh: bool = False) -> None:
+        return
+
+    def cancel_tower_analysis(self, analysis: Analysis) -> None:
+        return
+
+    def update_tower_run_status(self, analysis_id: int) -> None:
         return
 
     @staticmethod

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -15,6 +15,7 @@ from trailblazer.apps.tower.models import (
     TowerWorkflowResponse,
 )
 from trailblazer.constants import TOWER_STATUS, TrailblazerStatus
+from trailblazer.exc import TrailblazerError
 
 LOG = logging.getLogger(__name__)
 
@@ -87,8 +88,8 @@ class TowerApiClient:
                 LOG.info(f"POST request failed for url {url}\n with message {str(response)}")
                 response.raise_for_status()
         except (MissingSchema, HTTPError, ConnectionError) as error:
-            LOG.info("Request failed for url %s: Error: %s\n", url, error)
-            return {}
+            LOG.error("Request failed for url %s: Error: %s\n", url, error)
+            raise TrailblazerError
         return response.json()
 
     @property

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -80,7 +80,9 @@ class TowerApiClient:
         """Send data via POST request and return response."""
         try:
             LOG.info(f"Sending POST request with json data to {url}")
-            response = requests.post(url, headers=self.headers, json=data)
+            response = requests.post(
+                url, headers=self.headers, params=self.request_params, json=data
+            )
             if response.status_code == 404:
                 LOG.info(f"POST request failed for url {url}\n with message {str(response)}")
                 response.raise_for_status()

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -84,7 +84,7 @@ class TowerApiClient:
             response = requests.post(
                 url, headers=self.headers, params=self.request_params, json=data
             )
-            if response.status_code == 404:
+            if response.status_code in {404, 400}:
                 LOG.info(f"POST request failed for url {url}\n with message {str(response)}")
                 response.raise_for_status()
         except (MissingSchema, HTTPError, ConnectionError) as error:

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -30,6 +30,7 @@ class TowerApiClient:
         self.tower_api_endpoint: str = os.environ.get("TOWER_API_ENDPOINT", None)
         self.workflow_endpoint: str = f"workflow/{self.workflow_id}"
         self.tasks_endpoint: str = f"{self.workflow_endpoint}/tasks"
+        self.cancel_endpoint: str = f"{self.workflow_endpoint}/cancel"
 
     @property
     def headers(self) -> dict:
@@ -115,6 +116,13 @@ class TowerApiClient:
         if self.meets_requirements:
             url = self.build_url(endpoint=self.workflow_endpoint)
             return TowerWorkflowResponse(**self.send_request(url=url))
+
+    @property
+    def cancel(self) -> None:
+        """Send a POST request to cancel a workflow."""
+        if self.meets_requirements:
+            url: str = self.build_url(endpoint=self.cancel_endpoint)
+            self.post_request(url=url)
 
 
 class TowerAPI:

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -80,7 +80,6 @@ class TowerApiClient:
     def post_request(self, url: str, data: dict = {}) -> dict:
         """Send data via POST request and return response."""
         try:
-            LOG.info(f"Sending POST request with json data to {url}")
             response = requests.post(
                 url, headers=self.headers, params=self.request_params, json=data
             )
@@ -88,7 +87,7 @@ class TowerApiClient:
                 LOG.info(f"POST request failed for url {url}\n with message {str(response)}")
                 response.raise_for_status()
         except (MissingSchema, HTTPError, ConnectionError) as error:
-            LOG.error("Request failed for url %s: Error: %s\n", url, error)
+            LOG.error(f"Request failed for url {url}: Error: {error}\n")
             raise TrailblazerError
         return response.json()
 

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -38,6 +38,7 @@ class TowerApiClient:
         return {
             "Accept": "application/json",
             "Authorization": f"Bearer {self.tower_access_token}",
+            "Content-Type": "application/json",
         }
 
     @property
@@ -72,6 +73,19 @@ class TowerApiClient:
             LOG.info("Request failed for url %s: Error: %s\n", url, error)
             return {}
 
+        return response.json()
+
+    def post_request(self, url: str, data: dict = {}) -> dict:
+        """Send data via POST request and return response."""
+        try:
+            LOG.info(f"Sending POST request with json data to {url}")
+            response = requests.post(url, headers=self.headers, json=data)
+            if response.status_code == 404:
+                LOG.info(f"POST request failed for url {url}\n with message {str(response)}")
+                response.raise_for_status()
+        except (MissingSchema, HTTPError, ConnectionError) as error:
+            LOG.info("Request failed for url %s: Error: %s\n", url, error)
+            return {}
         return response.json()
 
     @property


### PR DESCRIPTION
## Description

Closes: https://github.com/Clinical-Genomics/trailblazer/issues/226

### Changed

- `cancel` supports NF-Tower cases


### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] activate stage: `us`
- [x] request trailblazer-stage on hasta: `paxa`
- [x] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b  cancel_tower_workflow -a
    ```

### How to test
- [x] Cancel not ongoing analysis: `trailblazer cancel 271983`. It should raise the following error: `TrailblazerError: Analysis 271983 is not running`
- [ ] Cancel ongoing analysis with failed tower response: `trailblazer cancel 271983`. It should raise the following error: `Request failed for url {url}: Error: {error}`
- [ ] Cancel ongoing analysis: `trailblazer cancel 271983`. It complete successfully with the following message: `Analysis 271983: all ongoing jobs cancelled successfully!`

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
