### PR TITLE
Migrate add user to createhandler 

### DIFF
--- a/tests/store/crud/test_create.py
+++ b/tests/store/crud/test_create.py
@@ -1,7 +1,8 @@
 from typing import List
 
 from tests.mocks.store_mock import MockStore
-from trailblazer.store.models import Analysis
+from trailblazer.store.filters.user_filters import apply_user_filter, UserFilter
+from trailblazer.store.models import Analysis, User
 
 
 def test_add_pending_analysis(raw_analyses: List[dict], store: MockStore, user_email: str):
@@ -30,3 +31,21 @@ def test_add_pending_analysis(raw_analyses: List[dict], store: MockStore, user_e
     )
     assert new_analysis and stored_analysis
     assert stored_analysis == new_analysis
+
+
+def test_add_user(store: MockStore, user_email: str, username: str):
+    """Test adding a user to the database."""
+    # GIVEN an empty database
+    assert not store.get_query(table=User).first()
+
+    # WHEN adding a new user
+    new_user: User = store.add_user(name=username, email=user_email)
+
+    # THEN it should be stored in the database
+    user: User = apply_user_filter(
+        filter_functions=[UserFilter.FILTER_BY_EMAIL],
+        users=store.get_query(table=User),
+        email=user_email,
+    ).first()
+    assert new_user
+    assert user == new_user

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -6,24 +6,6 @@ from trailblazer.store.filters.user_filters import apply_user_filter, UserFilter
 from trailblazer.store.models import User, Analysis
 
 
-def test_add_user(store: MockStore, user_email: str, username: str):
-    """Test adding a user to the database."""
-    # GIVEN an empty database
-    assert not store.get_query(table=User).first()
-
-    # WHEN adding a new user
-    new_user: User = store.add_user(name=username, email=user_email)
-
-    # THEN it should be stored in the database
-    user: User = apply_user_filter(
-        filter_functions=[UserFilter.FILTER_BY_EMAIL],
-        users=store.get_query(table=User),
-        email=user_email,
-    ).first()
-    assert new_user
-    assert user == new_user
-
-
 def test_update_user_is_archived(user_store: MockStore, user_email: str):
     """Test updating user is archived attribute."""
     # GIVE a database and a not archived user

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from trailblazer.constants import TrailblazerStatus
 from trailblazer.store.base import BaseHandler_2
-from trailblazer.store.models import Analysis
+from trailblazer.store.models import Analysis, User
 
 
 class CreateHandler(BaseHandler_2):
@@ -36,3 +36,9 @@ class CreateHandler(BaseHandler_2):
         new_analysis.user = self.get_user(email=email) if email else None
         self.add_commit(new_analysis)
         return new_analysis
+
+    def add_user(self, name: str, email: str) -> User:
+        """Add a new user to the database."""
+        new_user: User = User(email=email, name=name)
+        self.add_commit(new_user)
+        return new_user

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -7,12 +7,6 @@ from trailblazer.store.models import User, Analysis
 class UpdateHandler(BaseHandler_2):
     """Class for updating items in the database."""
 
-    def add_user(self, name: str, email: str) -> User:
-        """Add a new user to the database."""
-        new_user: User = User(email=email, name=name)
-        self.add_commit(new_user)
-        return new_user
-
     def update_user_is_archived(self, user: User, archive: bool = True) -> None:
         """Update is archived for a user in the database."""
         user.is_archived = archive


### PR DESCRIPTION
## Description
Migrate add_user function to createhandler as it is using INSERT


### Changed

- Migrate add_user function to createhandler 

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b migtate_add_user_to_createhandler -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
