### PR TITLE
fix(round_error): #254

### DIFF
--- a/tests/apps/slurm/test_api.py
+++ b/tests/apps/slurm/test_api.py
@@ -8,7 +8,7 @@ from trailblazer.apps.slurm.api import (
     reformat_squeue_result_job_step,
 )
 from trailblazer.apps.slurm.models import SqueueResult
-from trailblazer.constants import TrailblazerStatus, SlurmJobStatus, Pipeline
+from trailblazer.constants import Pipeline, SlurmJobStatus, TrailblazerStatus
 
 
 def test_get_squeue_result(squeue_stream_jobs):
@@ -99,6 +99,11 @@ def test_reformat_squeue_result_job_step_malformed_job_step(
         (
             "canceled_ongoing",
             {SlurmJobStatus.CANCELLED: 0.01, SlurmJobStatus.RUNNING: 0.1},
+            TrailblazerStatus.RUNNING,
+        ),
+        (
+            "canceled_ongoing_round_to_zero",
+            {SlurmJobStatus.CANCELLED: 0.01, SlurmJobStatus.RUNNING: 0.00},
             TrailblazerStatus.RUNNING,
         ),
     ],

--- a/trailblazer/apps/slurm/api.py
+++ b/trailblazer/apps/slurm/api.py
@@ -1,10 +1,10 @@
-from typing import List, Dict, Optional, Callable
+from typing import Callable, Dict, List, Optional
 
 from trailblazer.apps.slurm.models import SqueueResult
+from trailblazer.apps.slurm.utils import formatters
 from trailblazer.constants import FileFormat, SlurmJobStatus, TrailblazerStatus
 from trailblazer.exc import EmptySqueueError
 from trailblazer.io.controller import ReadStream
-from trailblazer.apps.slurm.utils import formatters
 
 
 def get_squeue_result(squeue_response: str) -> SqueueResult:
@@ -49,9 +49,9 @@ def _is_analysis_failed(jobs_status_distribution: Dict[str, float]) -> bool:
 
 def _is_analysis_ongoing(jobs_status_distribution: Dict[str, float]) -> bool:
     """Return True if analysis is still ongoing."""
-    return bool(
-        jobs_status_distribution.get(SlurmJobStatus.RUNNING)
-        or jobs_status_distribution.get(SlurmJobStatus.PENDING)
+    return any(
+        ongoing_status in jobs_status_distribution
+        for ongoing_status in TrailblazerStatus.ongoing_statuses()
     )
 
 


### PR DESCRIPTION
## Description

Fix incorrectly setting analysis status as canceled due to rounding to 0.

### Fixed

- Fix incorrectly setting analysis status as canceled due to rounding to 0. #254 

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b fix_wrong_tb_status -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
