### PR TITLE
Refactor get latest analysis

### DIFF
--- a/tests/apps/tower/conftest.py
+++ b/tests/apps/tower/conftest.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 import pytest
 
-from trailblazer.constants import TOWER_TIMESTAMP_FORMAT, TOWER_TIMESTAMP_FORMAT_EXTENDED
+from trailblazer.constants import (
+    TOWER_TIMESTAMP_FORMAT,
+    TOWER_TIMESTAMP_FORMAT_EXTENDED,
+)
 
 TOWER_RESPONSE_DIR: Path = Path("tests", "fixtures", "tower")
 TOWER_ID: str = "1m759EPcbjuK7n"
@@ -23,7 +26,7 @@ class TowerTaskResponseFile:
     EMPTY: Path = Path(TOWER_RESPONSE_DIR, "tower_tasks_empty.json")
 
 
-class CaseIDs:
+class CaseName:
     PENDING: str = "cuddlyhen_pending"
     RUNNING: str = "cuddlyhen"
     COMPLETED: str = "cuddlyhen_completed"

--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -91,7 +91,7 @@ def test_set_analysis_status(
     # THEN command runs successfully
     assert result.exit_code == process_exit_success
 
-    # THEN status will be set to COMPLETED
+    # THEN status will be set to "qc
     analysis = trailblazer_db.get_latest_analysis_for_case(case_name=failed_analysis_case_name)
     assert analysis.status == TrailblazerStatus.QC
 
@@ -277,6 +277,9 @@ def test_delete_ongoing_force(
 
     # THEN log informs user that Trailblazer is deleting analysis
     assert "Deleting" in caplog.text
+
+    # THEN the analysis should have been deleted from the database
+    assert not trailblazer_db.get_latest_analysis_for_case(case_name=analysis.family)
 
 
 def test_get_user_not_in_database(

--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -482,7 +482,7 @@ def test_scan(
 
 
 @pytest.mark.parametrize(
-    "case_id, status",
+    "case_name, status",
     [
         ("blazinginsect", TrailblazerStatus.RUNNING),
         ("crackpanda", TrailblazerStatus.FAILED),
@@ -494,7 +494,7 @@ def test_ls(
     cli_runner: CliRunner,
     process_exit_success: int,
     trailblazer_context: Dict[str, MockStore],
-    case_id: str,
+    case_name: str,
     status: str,
     timestamp_now: datetime,
 ):
@@ -514,4 +514,4 @@ def test_ls(
     assert result.exit_code == process_exit_success
 
     # THEN ls print info about cases with that status
-    assert case_id in result.output
+    assert case_name in result.output

--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Optional
 
 import pytest
 from click.testing import CliRunner
@@ -21,7 +21,6 @@ from trailblazer.cli.core import (
     unarchive_user,
 )
 from trailblazer.constants import SlurmJobStatus, TrailblazerStatus
-from trailblazer.store.api import Store
 from trailblazer.store.models import Analysis
 
 
@@ -36,60 +35,79 @@ def test_base(cli_runner):
     assert trailblazer.__version__ in result.output
 
 
-def test_set_analysis_completed(cli_runner, trailblazer_context, caplog):
-    # GIVEN an analysis with status FAILED
-    failed_analysis = "crackpanda"
-    analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(case_id=failed_analysis)
+def test_set_analysis_completed(
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    failed_analysis_case_name: str,
+):
+    """Test setting an analysis to status complete."""
+    # GIVEN an analysis with status failed
+    trailblazer_db: MockStore = trailblazer_context["trailblazer"]
+    analysis: Optional[Analysis] = trailblazer_db.get_latest_analysis_for_case(
+        case_name=failed_analysis_case_name
+    )
 
     # Make sure status is not "completed"
-    assert analysis_obj.status != "completed"
+    assert analysis.status != TrailblazerStatus.COMPLETED
+
+    # WHEN running command
+    result = cli_runner.invoke(set_analysis_completed, [str(analysis.id)], obj=trailblazer_context)
+
+    # THEN command runs successfully
+    assert result.exit_code == 0
+
+    # THEN status will be set to "complete"
+    analysis: Optional[Analysis] = trailblazer_db.get_latest_analysis_for_case(
+        case_name=failed_analysis_case_name
+    )
+    assert analysis.status == TrailblazerStatus.COMPLETED
+
+
+def test_set_analysis_status(
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    failed_analysis_case_name: str,
+):
+    """Test that the latest analysis status is updated for a given case name."""
+
+    # GIVEN an analysis with status failed
+    trailblazer_db: MockStore = trailblazer_context["trailblazer"]
+    analysis: Optional[Analysis] = trailblazer_db.get_latest_analysis_for_case(
+        case_name=failed_analysis_case_name
+    )
+
+    # Make sure status is not "qc"
+    assert analysis.status != TrailblazerStatus.QC
 
     # WHEN running command
     result = cli_runner.invoke(
-        set_analysis_completed, [str(analysis_obj.id)], obj=trailblazer_context
+        set_analysis_status, ["--status", "qc", failed_analysis_case_name], obj=trailblazer_context
     )
 
     # THEN command runs successfully
     assert result.exit_code == 0
 
     # THEN status will be set to COMPLETED
-    analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(case_id=failed_analysis)
-    assert analysis_obj.status == "completed"
+    analysis = trailblazer_db.get_latest_analysis_for_case(case_name=failed_analysis_case_name)
+    assert analysis.status == TrailblazerStatus.QC
 
 
-def test_set_analysis_status(cli_runner, trailblazer_context, caplog) -> None:
-    """Test that the lastest analysis status is updated for a given case ID."""
-
-    # GIVEN an analysis with status FAILED
-    failed_analysis = "crackpanda"
-    analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(case_id=failed_analysis)
-
-    # Make sure status is not "completed"
-    assert analysis_obj.status != "qc"
-
-    # WHEN running command
-    result = cli_runner.invoke(
-        set_analysis_status, ["--status", "qc", failed_analysis], obj=trailblazer_context
-    )
-
-    # THEN command runs successfully
-    assert result.exit_code == 0
-
-    # THEN status will be set to COMPLETED
-    analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(case_id=failed_analysis)
-    assert analysis_obj.status == "qc"
-
-
-def test_set_analysis_status_error(cli_runner, trailblazer_context, caplog) -> None:
+def test_set_analysis_status_error(
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    failed_analysis_case_name: str,
+):
     """Test that setting the status to a non-accepted value raises an error."""
 
-    # GIVEN an analysis with status FAILED
-    failed_analysis = "crackpanda"
+    # GIVEN an analysis with status failed
 
     # WHEN running command
     result = cli_runner.invoke(
         set_analysis_status,
-        ["--status", "non_existing_status", failed_analysis],
+        ["--status", "non_existing_status", failed_analysis_case_name],
         obj=trailblazer_context,
     )
 
@@ -98,47 +116,67 @@ def test_set_analysis_status_error(cli_runner, trailblazer_context, caplog) -> N
     assert "Invalid status" in caplog.text
 
 
-def test_cancel_nonexistent(cli_runner, trailblazer_context, caplog):
-    with caplog.at_level("ERROR"):
-        # GIVEN Trailblazer database with analyses and jobs
-        trailblazer_context["trailblazer"].update_ongoing_analyses()
+def test_cancel_non_existent_analysis_id(
+    cli_runner: CliRunner, trailblazer_context: Dict[str, MockStore], caplog
+):
+    """Test cancelling an analysis using a non existing analysis id."""
+    caplog.set_level("ERROR")
 
-        # WHEN running cancel on non-existing entry
-        result = cli_runner.invoke(cancel, ["123"], obj=trailblazer_context)
+    # GIVEN Trailblazer database with analyses and jobs
+    trailblazer_db: MockStore = trailblazer_context["trailblazer"]
+    trailblazer_db.update_ongoing_analyses()
 
-        # THEN command runs successfully
-        assert result.exit_code == 0
+    # WHEN running cancel on non-existing entry
+    result = cli_runner.invoke(cancel, ["123"], obj=trailblazer_context)
 
-        # THEN error log informs user that analysis does not exist
-        assert "does not exist" in caplog.text
+    # THEN command runs successfully
+    assert result.exit_code == 0
 
-
-def test_cancel_not_running(cli_runner, trailblazer_context, caplog):
-    with caplog.at_level("ERROR"):
-        # GIVEN an analysis that is NOT running
-        failed_analysis = "crackpanda"
-        analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(
-            case_id=failed_analysis
-        )
-        # WHEN trying to cancel analysis
-        trailblazer_context["trailblazer"].update_ongoing_analyses()
-        result = cli_runner.invoke(cancel, [str(analysis_obj.id)], obj=trailblazer_context)
-
-        # THEN command runs successfully
-        assert result.exit_code == 0
-
-        # THEN error log informs user that analysis cannot be cancelled as it is not running
-        assert "is not running" in caplog.text
+    # THEN error log informs user that analysis does not exist
+    assert "does not exist" in caplog.text
 
 
-def test_cancel_ongoing_analysis(cli_runner, trailblazer_context, caplog):
+def test_cancel_not_running(
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    failed_analysis_case_name: str,
+):
+    """Test cancelling an analysis, which is not running."""
+    caplog.set_level("ERROR")
+
+    # GIVEN an analysis that is NOT running
+    trailblazer_db: MockStore = trailblazer_context["trailblazer"]
+    analysis: Optional[Analysis] = trailblazer_db.get_latest_analysis_for_case(
+        case_name=failed_analysis_case_name
+    )
+    trailblazer_db.update_ongoing_analyses()
+
+    # WHEN trying to cancel analysis
+    result = cli_runner.invoke(cancel, [str(analysis.id)], obj=trailblazer_context)
+
+    # THEN command runs successfully
+    assert result.exit_code == 0
+
+    # THEN error log informs user that analysis cannot be cancelled as it is not running
+    assert "is not running" in caplog.text
+
+
+def test_cancel_ongoing_analysis(
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    ongoing_analysis_case_name: str,
+):
     """Test all ongoing analysis jobs are cancelled."""
     caplog.set_level("INFO")
 
     # GIVEN an ongoing analysis
-    trailblazer_db: Store = trailblazer_context["trailblazer"]
+    trailblazer_db: MockStore = trailblazer_context["trailblazer"]
     trailblazer_db.update_ongoing_analyses()
-    analysis: Analysis = trailblazer_db.get_latest_analysis(case_id="blazinginsect")
+    analysis: Optional[Analysis] = trailblazer_db.get_latest_analysis_for_case(
+        case_name=ongoing_analysis_case_name
+    )
 
     # Analysis should have jobs that can be cancelled
     assert analysis.jobs
@@ -161,10 +199,13 @@ def test_cancel_ongoing_analysis(cli_runner, trailblazer_context, caplog):
     assert analysis.status == TrailblazerStatus.CANCELLED
 
 
-def test_delete_nonexisting(cli_runner, trailblazer_context, caplog):
+def test_delete_nonexisting(
+    cli_runner: CliRunner, trailblazer_context: Dict[str, MockStore], caplog
+):
     with caplog.at_level("ERROR"):
         # GIVEN Trailblazer database with analyses and jobs
-        trailblazer_context["trailblazer"].update_ongoing_analyses()
+        trailblazer_db: MockStore = trailblazer_context["trailblazer"]
+        trailblazer_db.update_ongoing_analyses()
 
         # WHEN trying to delete analysis not in database
         cli_runner.invoke(delete, ["123"], obj=trailblazer_context)
@@ -173,46 +214,65 @@ def test_delete_nonexisting(cli_runner, trailblazer_context, caplog):
         assert "Analysis not found" in caplog.text
 
 
-def test_delete_ongoing_fail(cli_runner, trailblazer_context, caplog):
-    with caplog.at_level("ERROR"):
-        # GIVEN Trailblazer database with analyses and jobs
-        trailblazer_context["trailblazer"].update_ongoing_analyses()
+def test_delete_ongoing_fail(
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    ongoing_analysis_case_name,
+):
+    """Test deleting an ongoing analysis without using the force flag."""
+    caplog.set_level("ERROR")
 
-        # GIVEN an analysis that is ongoing
-        analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(case_id="escapedgoat")
+    # GIVEN Trailblazer database with analyses and jobs
+    trailblazer_db: MockStore = trailblazer_context["trailblazer"]
+    trailblazer_db.update_ongoing_analyses()
 
-        # WHEN trying to delete ongoing analysis without --force flag
-        result = cli_runner.invoke(delete, [str(analysis_obj.id)], obj=trailblazer_context)
+    # GIVEN an analysis that is ongoing
+    analysis: Optional[Analysis] = trailblazer_db.get_latest_analysis_for_case(
+        case_name=ongoing_analysis_case_name
+    )
 
-        # THEN command executes successfully
-        assert result.exit_code == 0
+    # WHEN trying to delete ongoing analysis without --force flag
+    result = cli_runner.invoke(delete, [str(analysis.id)], obj=trailblazer_context)
 
-        # THEN error log informs user that ongoing analysis cannot be deleted without --force flag
-        assert "--force" in caplog.text
+    # THEN command executes successfully
+    assert result.exit_code == 0
 
-        # THEN analysis should not be cancelled
-        assert analysis_obj.status != "canceled"
+    # THEN error log informs user that ongoing analysis cannot be deleted without --force flag
+    assert "--force" in caplog.text
 
-
-def test_delete_ongoing_force(cli_runner, trailblazer_context, caplog):
-    with caplog.at_level("INFO"):
-        # GIVEN Trailblazer database with analyses and jobs and an ongoing analysis
-        trailblazer_context["trailblazer"].update_ongoing_analyses()
-        analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(case_id="escapedgoat")
-
-        # WHEN running command with --force flag
-        result = cli_runner.invoke(
-            delete, [str(analysis_obj.id), "--force"], obj=trailblazer_context
-        )
-
-        # THEN command runs successfully
-        assert result.exit_code == 0
-
-        # THEN log informs user that Trailblazer is deleting analysis
-        assert "Deleting" in caplog.text
+    # THEN analysis should not be cancelled
+    assert analysis.status != TrailblazerStatus.CANCELLED
 
 
-def test_get_user_not_in_database(cli_runner, trailblazer_context: Dict[str, MockStore], caplog):
+def test_delete_ongoing_force(
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    ongoing_analysis_case_name,
+):
+    caplog.set_level("INFO")
+
+    # GIVEN Trailblazer database with analyses and jobs and an ongoing analysis
+    trailblazer_db: MockStore = trailblazer_context["trailblazer"]
+    trailblazer_db.update_ongoing_analyses()
+    analysis: Optional[Analysis] = trailblazer_db.get_latest_analysis_for_case(
+        case_name=ongoing_analysis_case_name
+    )
+
+    # WHEN running command with --force flag
+    result = cli_runner.invoke(delete, [str(analysis.id), "--force"], obj=trailblazer_context)
+
+    # THEN command runs successfully
+    assert result.exit_code == 0
+
+    # THEN log informs user that Trailblazer is deleting analysis
+    assert "Deleting" in caplog.text
+
+
+def test_get_user_not_in_database(
+    cli_runner: CliRunner, trailblazer_context: Dict[str, MockStore], caplog
+):
     """Test getting user when user is not in the database."""
     # GIVEN populated Trailblazer database
 
@@ -226,7 +286,11 @@ def test_get_user_not_in_database(cli_runner, trailblazer_context: Dict[str, Moc
 
 
 def test_get_user_in_database(
-    cli_runner, trailblazer_context: Dict[str, MockStore], caplog, user_email: str, username: str
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    user_email: str,
+    username: str,
 ):
     """Test getting user when user is in the database."""
     # GIVEN populated Trailblazer database
@@ -239,7 +303,7 @@ def test_get_user_in_database(
     assert username in caplog.text
 
 
-def test_add_user(cli_runner, trailblazer_context: Dict[str, MockStore], caplog):
+def test_add_user(cli_runner: CliRunner, trailblazer_context: Dict[str, MockStore], caplog):
     """Test adding a user to the database."""
     # GIVEN populated Trailblazer database
 
@@ -255,7 +319,11 @@ def test_add_user(cli_runner, trailblazer_context: Dict[str, MockStore], caplog)
 
 
 def test_add_user_when_already_exists(
-    cli_runner, trailblazer_context: Dict[str, MockStore], caplog, user_email: str, username: str
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    user_email: str,
+    username: str,
 ):
     """Test adding a user to the database when the user already exists."""
     # GIVEN populated Trailblazer database
@@ -270,7 +338,11 @@ def test_add_user_when_already_exists(
 
 
 def test_users(
-    cli_runner, trailblazer_context: Dict[str, MockStore], caplog, user_email: str, username: str
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    user_email: str,
+    username: str,
 ):
     """Test getting users from the database."""
     # GIVEN populated Trailblazer database
@@ -285,7 +357,7 @@ def test_users(
 
 
 def test_archive_user(
-    cli_runner, trailblazer_context: Dict[str, MockStore], caplog, user_email: str
+    cli_runner: CliRunner, trailblazer_context: Dict[str, MockStore], caplog, user_email: str
 ):
     """Test archiving a user in the database."""
     # GIVEN populated Trailblazer database
@@ -300,7 +372,10 @@ def test_archive_user(
 
 
 def test_archive_user_when_already_archived(
-    cli_runner, trailblazer_context: Dict[str, MockStore], caplog, archived_user_email: str
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    archived_user_email: str,
 ):
     """Test archiving a user in the database when already archived."""
     # GIVEN populated Trailblazer database
@@ -315,7 +390,10 @@ def test_archive_user_when_already_archived(
 
 
 def test_archive_user_when_non_existing_user(
-    cli_runner, trailblazer_context: Dict[str, MockStore], caplog, archived_user_email: str
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    archived_user_email: str,
 ):
     """Test archiving a user in the database when user does not exist."""
     # GIVEN populated Trailblazer database
@@ -331,7 +409,7 @@ def test_archive_user_when_non_existing_user(
 
 
 def test_unarchive_user_when_not_archived(
-    cli_runner, trailblazer_context: Dict[str, MockStore], caplog, user_email: str
+    cli_runner: CliRunner, trailblazer_context: Dict[str, MockStore], caplog, user_email: str
 ):
     """Test unarchiving a user in the database which is not archived."""
     # GIVEN populated Trailblazer database
@@ -346,7 +424,10 @@ def test_unarchive_user_when_not_archived(
 
 
 def test_unarchive_user(
-    cli_runner, trailblazer_context: Dict[str, MockStore], caplog, archived_user_email: str
+    cli_runner: CliRunner,
+    trailblazer_context: Dict[str, MockStore],
+    caplog,
+    archived_user_email: str,
 ):
     """Test unarchiving a user in the database which is archived."""
     # GIVEN populated Trailblazer database
@@ -360,22 +441,19 @@ def test_unarchive_user(
     assert f"User unarchived: {archived_user_email}" in caplog.text
 
 
-def test_scan(cli_runner, trailblazer_context, caplog):
+def test_scan(cli_runner: CliRunner, trailblazer_context: Dict[str, MockStore], caplog):
     with caplog.at_level("INFO"):
         # GIVEN populated Trailblazer database with pending analyses
 
         # GIVEN an analysis that is pending
-        analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(
-            case_id="blazinginsect"
-        )
+        trailblazer_db: MockStore = trailblazer_context["trailblazer"]
+        analysis_obj = trailblazer_db.get_latest_analysis(case_id="blazinginsect")
         assert analysis_obj.status == "pending"
 
         # WHEN running trailblazer scan command
         cli_runner.invoke(scan, [], obj=trailblazer_context)
         assert "All analyses updated" in caplog.text
-        analysis_obj = trailblazer_context["trailblazer"].get_latest_analysis(
-            case_id="blazinginsect"
-        )
+        analysis_obj = trailblazer_db.get_latest_analysis(case_id="blazinginsect")
 
         # THEN the stats of analysis should be updated as expected
         assert analysis_obj.status == "running"
@@ -400,7 +478,7 @@ def test_ls(
 ):
     """Test the Traiblazer ls CLI command using different cases and statuses."""
     # GIVEN populated Trailblazer database with pending analyses
-    trailblazer_db: Store = trailblazer_context["trailblazer"]
+    trailblazer_db: MockStore = trailblazer_context["trailblazer"]
 
     # Update analyses to their expected status
     trailblazer_db.update_ongoing_analyses()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Dict, Generator, List
 
 import pytest
 
-from tests.apps.tower.conftest import CaseIDs, TowerTaskResponseFile
+from tests.apps.tower.conftest import CaseName, TowerTaskResponseFile
 from tests.mocks.store_mock import MockStore
 from tests.store.utils.store_helper import StoreHelpers
 from trailblazer.apps.tower.models import TowerTask
@@ -127,7 +127,7 @@ def fixture_raw_analyses(analysis_data: Dict[str, List[Dict]]) -> List[dict]:
     """Return raw analyses data."""
     analyses: List[dict] = []
     for analysis in analysis_data["analyses"]:
-        analysis["case_id"] = analysis["family"]
+        analysis["case_name"] = analysis["family"]
         analyses.append(analysis)
     return analyses
 
@@ -220,10 +220,10 @@ def fixture_tower_task_name() -> str:
     return "NFCORE_RNAFUSION:RNAFUSION:INPUT_CHECK:SAMPLESHEET_CHECK"
 
 
-@pytest.fixture(name="case_id", scope="session")
-def fixture_case_id() -> str:
-    """Return a case ID."""
-    return CaseIDs.RUNNING
+@pytest.fixture(scope="session")
+def case_name() -> str:
+    """Return a case name."""
+    return CaseName.RUNNING
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Generator
+from typing import Dict, Generator, List
 
 import pytest
 
 from tests.apps.tower.conftest import CaseIDs, TowerTaskResponseFile
 from tests.mocks.store_mock import MockStore
-from trailblazer.apps.tower.models import TowerTask
-from trailblazer.constants import TOWER_TIMESTAMP_FORMAT, TrailblazerStatus, FileFormat
-from trailblazer.io.controller import ReadFile
 from tests.store.utils.store_helper import StoreHelpers
+from trailblazer.apps.tower.models import TowerTask
+from trailblazer.constants import TOWER_TIMESTAMP_FORMAT, FileFormat, TrailblazerStatus
+from trailblazer.io.controller import ReadFile
 
 
 @pytest.fixture(scope="session", name="username")
@@ -224,6 +224,12 @@ def fixture_tower_task_name() -> str:
 def fixture_case_id() -> str:
     """Return a case ID."""
     return CaseIDs.RUNNING
+
+
+@pytest.fixture(scope="session")
+def case_name_not_in_db() -> str:
+    """Return a case name not present in database."""
+    return "case_name_not_in_db"
 
 
 @pytest.fixture(name="tower_task", scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,6 +232,18 @@ def case_name_not_in_db() -> str:
     return "case_name_not_in_db"
 
 
+@pytest.fixture(scope="session")
+def failed_analysis_case_name() -> str:
+    """Return a case name for a failed analysis."""
+    return "crackpanda"
+
+
+@pytest.fixture(scope="session")
+def ongoing_analysis_case_name() -> str:
+    """Return a case name for an ongoing analysis."""
+    return "blazinginsect"
+
+
 @pytest.fixture(name="tower_task", scope="session")
 def fixture_tower_task() -> TowerTask:
     """Return a Tower task."""

--- a/tests/mocks/store_mock.py
+++ b/tests/mocks/store_mock.py
@@ -1,7 +1,12 @@
 import subprocess
 from pathlib import Path
 
-from tests.apps.tower.conftest import TOWER_ID, CaseIDs, TowerResponseFile, TowerTaskResponseFile
+from tests.apps.tower.conftest import (
+    TOWER_ID,
+    CaseName,
+    TowerResponseFile,
+    TowerTaskResponseFile,
+)
 from tests.mocks.tower_mock import MockTowerAPI
 from trailblazer.constants import FileExtension
 from trailblazer.store.api import Store
@@ -59,19 +64,19 @@ class MockStore(Store):
     def query_tower(config_file: str, case_id: str) -> MockTowerAPI:
         """Return a mocked NF Tower API response."""
         configs = {
-            CaseIDs.RUNNING: {
+            CaseName.RUNNING: {
                 "workflow_response_file": TowerResponseFile.RUNNING,
                 "tasks_response_file": TowerTaskResponseFile.RUNNING,
                 "tower_id": TOWER_ID,
                 "analysis_id": 1,
             },
-            CaseIDs.PENDING: {
+            CaseName.PENDING: {
                 "workflow_response_file": TowerResponseFile.PENDING,
                 "tasks_response_file": TowerTaskResponseFile.PENDING,
                 "tower_id": TOWER_ID,
                 "analysis_id": 1,
             },
-            CaseIDs.COMPLETED: {
+            CaseName.COMPLETED: {
                 "workflow_response_file": TowerResponseFile.COMPLETED,
                 "tasks_response_file": TowerTaskResponseFile.COMPLETED,
                 "tower_id": TOWER_ID,

--- a/tests/store/crud/test_delete.py
+++ b/tests/store/crud/test_delete.py
@@ -4,11 +4,11 @@ from tests.mocks.store_mock import MockStore
 from trailblazer.store.models import Analysis
 
 
-def test_delete_analysis_jobs(analysis_store: MockStore, tower_jobs: List[dict], case_id: str):
+def test_delete_analysis_jobs(analysis_store: MockStore, tower_jobs: List[dict], case_name: str):
     """Test jobs are successfully deleted."""
 
     # GIVEN an analysis without failed jobs
-    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_name)
     assert not analysis.jobs
 
     # WHEN jobs are updated

--- a/tests/store/crud/test_delete.py
+++ b/tests/store/crud/test_delete.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from tests.mocks.store_mock import MockStore
 from trailblazer.store.models import Analysis
@@ -8,7 +8,7 @@ def test_delete_analysis_jobs(analysis_store: MockStore, tower_jobs: List[dict],
     """Test jobs are successfully deleted."""
 
     # GIVEN an analysis without failed jobs
-    analysis: Analysis = analysis_store.get_latest_analysis(case_id=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
     assert not analysis.jobs
 
     # WHEN jobs are updated

--- a/tests/store/crud/test_read.py
+++ b/tests/store/crud/test_read.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from tests.mocks.store_mock import MockStore
 from tests.store.utils.store_helper import StoreHelpers
@@ -23,13 +23,43 @@ def test_get_analysis(analysis_store: MockStore):
     assert analysis == existing_analysis
 
 
+def test_get_latest_analysis_for_case(analysis_store: MockStore):
+    """Test getting an analysis fora case when it exists in the database."""
+    # GIVEN a store with an analysis
+    existing_analysis: Analysis = analysis_store.get_query(table=Analysis).first()
+
+    # WHEN accessing it by case name
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(
+        case_name=existing_analysis.family
+    )
+
+    # THEN it should return the same analysis
+    assert analysis == existing_analysis
+
+
+def test_get_latest_analysis_for_case_when_missing(
+    analysis_store: MockStore, case_name_not_in_db: str
+):
+    """Test getting an analysis fora case when it does not exist in the database."""
+
+    # WHEN accessing it by case name
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(
+        case_name=case_name_not_in_db
+    )
+
+    # THEN no analysis should be returned
+    assert not analysis
+
+
 def test_get_analysis_with_id(analysis_store: MockStore):
     """Test getting an analysis by id when it exists in the database."""
     # GIVEN a store with an analysis
     existing_analysis: Analysis = analysis_store.get_query(table=Analysis).first()
 
     # WHEN accessing it by ID
-    analysis: Analysis = analysis_store.get_analysis_with_id(analysis_id=existing_analysis.id)
+    analysis: Optional[Analysis] = analysis_store.get_analysis_with_id(
+        analysis_id=existing_analysis.id
+    )
 
     # THEN it should return the same analysis
     assert analysis == existing_analysis
@@ -41,7 +71,9 @@ def test_get_analysis_with_id_when_missing(analysis_store: MockStore):
     missing_analysis_id: int = 12312423534
 
     # WHEN accessing the analysis
-    analysis: Analysis = analysis_store.get_analysis_with_id(analysis_id=missing_analysis_id)
+    analysis: Optional[Analysis] = analysis_store.get_analysis_with_id(
+        analysis_id=missing_analysis_id
+    )
 
     # THEN it should return None
     assert not analysis

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -8,11 +8,11 @@ from trailblazer.store.filters.user_filters import UserFilter, apply_user_filter
 from trailblazer.store.models import Analysis, User
 
 
-def test_update_analysis_jobs(analysis_store: MockStore, tower_jobs: List[dict], case_id: str):
+def test_update_analysis_jobs(analysis_store: MockStore, tower_jobs: List[dict], case_name: str):
     """Test jobs are successfully updated."""
 
     # GIVEN an analysis with no jobs
-    analysis: Analysis = analysis_store.get_latest_analysis_for_case(case_name=case_id)
+    analysis: Analysis = analysis_store.get_latest_analysis_for_case(case_name=case_name)
     assert not analysis.jobs
 
     # WHEN jobs are updated

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -11,8 +11,8 @@ from trailblazer.store.models import Analysis, User
 def test_update_analysis_jobs(analysis_store: MockStore, tower_jobs: List[dict], case_id: str):
     """Test jobs are successfully updated."""
 
-    # GIVEN an analysis without failed jobs
-    analysis: Analysis = analysis_store.get_latest_analysis(case_id=case_id)
+    # GIVEN an analysis with no jobs
+    analysis: Analysis = analysis_store.get_latest_analysis_for_case(case_name=case_id)
     assert not analysis.jobs
 
     # WHEN jobs are updated

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import pytest
 
-from tests.apps.tower.conftest import CaseIDs
+from tests.apps.tower.conftest import CaseName
 from tests.mocks.store_mock import MockStore
 from trailblazer.constants import TrailblazerStatus
 from trailblazer.store.models import Analysis
@@ -58,11 +58,11 @@ def test_is_latest_analysis_ongoing(analysis_store: MockStore, family: str, expe
     assert is_ongoing is expected_bool
 
 
-def test_set_analysis_uploaded(analysis_store: MockStore, timestamp_now: datetime, case_id):
+def test_set_analysis_uploaded(analysis_store: MockStore, timestamp_now: datetime, case_name):
     """Test setting analysis uploaded at for an analysis."""
 
     # GIVEN a store with an analysis
-    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_name)
 
     # WHEN setting an analysis uploaded at
     analysis_store.set_analysis_uploaded(case_id=analysis.family, uploaded_at=timestamp_now)
@@ -71,11 +71,11 @@ def test_set_analysis_uploaded(analysis_store: MockStore, timestamp_now: datetim
     assert analysis.uploaded_at == timestamp_now
 
 
-def test_set_analysis_failed(analysis_store: MockStore, case_id: str):
+def test_set_analysis_failed(analysis_store: MockStore, case_name: str):
     """Test setting analysis to failed for an analysis."""
 
     # GIVEN a store with an analysis
-    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_name)
 
     # WHEN setting analysis to failed
     analysis_store.set_analysis_status(case_id=analysis.family, status=TrailblazerStatus.FAILED)
@@ -84,11 +84,11 @@ def test_set_analysis_failed(analysis_store: MockStore, case_id: str):
     assert analysis.status == TrailblazerStatus.FAILED
 
 
-def test_add_comment(analysis_store: MockStore, case_id: str):
+def test_add_comment(analysis_store: MockStore, case_name: str):
     """Test adding comment to an analysis object."""
 
     # GIVEN a store with an analysis
-    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_name)
     comment: str = "test comment"
 
     # WHEN adding a comment
@@ -168,7 +168,7 @@ def test_get_latest_analysis_status(
 
 
 @pytest.mark.parametrize(
-    "case_id, status",
+    "case_name, status",
     [
         ("blazinginsect", TrailblazerStatus.RUNNING),
         ("crackpanda", TrailblazerStatus.FAILED),
@@ -184,10 +184,10 @@ def test_get_latest_analysis_status(
         ("trueferret", TrailblazerStatus.RUNNING),
     ],
 )
-def test_update_run_status(analysis_store: MockStore, case_id: str, status: str):
+def test_update_run_status(analysis_store: MockStore, case_name: str, status: str):
     """Test updating an analysis status."""
     # GIVEN an analysis
-    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_name)
 
     # WHEN database is updated once
     analysis_store.update_run_status(analysis_id=analysis.id)
@@ -220,11 +220,11 @@ def test_mark_analyses_deleted(analysis_store: MockStore, ongoing_analysis_case_
     assert analysis.is_deleted
 
 
-def test_update_tower_jobs(analysis_store: MockStore, tower_jobs: List[dict], case_id: str):
+def test_update_tower_jobs(analysis_store: MockStore, tower_jobs: List[dict], case_name: str):
     """Assess that jobs are successfully updated when using NF Tower."""
 
     # GIVEN an analysis without failed jobs
-    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_name)
     assert not analysis.jobs
 
     # WHEN analysis jobs are deleted
@@ -241,20 +241,20 @@ def test_update_tower_jobs(analysis_store: MockStore, tower_jobs: List[dict], ca
 
 
 @pytest.mark.parametrize(
-    "case_id, status, progress",
+    "case_name, status, progress",
     [
-        (CaseIDs.RUNNING, TrailblazerStatus.RUNNING, 0.15),
-        (CaseIDs.PENDING, TrailblazerStatus.PENDING, 0),
-        (CaseIDs.COMPLETED, TrailblazerStatus.QC, 1),
+        (CaseName.RUNNING, TrailblazerStatus.RUNNING, 0.15),
+        (CaseName.PENDING, TrailblazerStatus.PENDING, 0),
+        (CaseName.COMPLETED, TrailblazerStatus.QC, 1),
     ],
 )
 def test_update_tower_run_status(
-    analysis_store: MockStore, case_id: str, status: str, progress: int
+    analysis_store: MockStore, case_name: str, status: str, progress: int
 ):
     """Assess that an analysis status is successfully updated when using NF Tower."""
 
     # GIVEN an analysis with pending status
-    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_name)
     assert analysis.status == TrailblazerStatus.PENDING
 
     # WHEN database is updated once

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List
+from typing import List, Optional
 
 import pytest
 
@@ -58,45 +58,44 @@ def test_is_latest_analysis_ongoing(analysis_store: MockStore, family: str, expe
     assert is_ongoing is expected_bool
 
 
-def test_set_analysis_uploaded(analysis_store: MockStore, timestamp_now: datetime):
+def test_set_analysis_uploaded(analysis_store: MockStore, timestamp_now: datetime, case_id):
     """Test setting analysis uploaded at for an analysis."""
 
     # GIVEN a store with an analysis
-    analysis_obj: Analysis = analysis_store.analyses().first()
-    uploaded_at: datetime = timestamp_now
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
 
     # WHEN setting an analysis uploaded at
-    analysis_store.set_analysis_uploaded(case_id=analysis_obj.family, uploaded_at=uploaded_at)
+    analysis_store.set_analysis_uploaded(case_id=analysis.family, uploaded_at=timestamp_now)
 
     # THEN the column uploaded_at should be updated
-    assert analysis_obj.uploaded_at == uploaded_at
+    assert analysis.uploaded_at == timestamp_now
 
 
-def test_set_analysis_failed(analysis_store: MockStore):
+def test_set_analysis_failed(analysis_store: MockStore, case_id: str):
     """Test setting analysis to failed for an analysis."""
 
     # GIVEN a store with an analysis
-    analysis_obj: Analysis = analysis_store.analyses().first()
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
 
     # WHEN setting analysis to failed
-    analysis_store.set_analysis_status(case_id=analysis_obj.family, status="failed")
+    analysis_store.set_analysis_status(case_id=analysis.family, status=TrailblazerStatus.FAILED)
 
-    # THEN the column status should be updated with failed.
-    assert analysis_obj.status == "failed"
+    # THEN the analysis status should be updated to failed.
+    assert analysis.status == TrailblazerStatus.FAILED
 
 
-def test_add_comment(analysis_store: MockStore):
+def test_add_comment(analysis_store: MockStore, case_id: str):
     """Test adding comment to an analysis object."""
 
     # GIVEN a store with an analysis
-    analysis_obj: Analysis = analysis_store.analyses().first()
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
     comment: str = "test comment"
 
     # WHEN adding a comment
-    analysis_store.add_comment(case_id=analysis_obj.family, comment=comment)
+    analysis_store.add_comment(case_id=analysis.family, comment=comment)
 
     # THEN a comment should have been added
-    assert analysis_obj.comment == comment
+    assert analysis.comment == comment
 
 
 @pytest.mark.parametrize(
@@ -144,80 +143,88 @@ def test_is_latest_analysis_completed(analysis_store: MockStore, family: str, ex
 
 
 @pytest.mark.parametrize(
-    "family, expected_status",
+    "case_name, expected_status",
     [
-        ("blazinginsect", "running"),  # running
-        ("nicemice", "completed"),  # completed
-        ("lateraligator", "failed"),  # failed
-        ("escapedgoat", "pending"),  # pending
+        ("blazinginsect", TrailblazerStatus.RUNNING),
+        ("nicemice", TrailblazerStatus.COMPLETED),
+        ("lateraligator", TrailblazerStatus.FAILED),
+        ("escapedgoat", TrailblazerStatus.PENDING),
     ],
 )
-def test_get_latest_analysis_status(analysis_store: MockStore, family: str, expected_status: str):
+def test_get_latest_analysis_status(
+    analysis_store: MockStore, case_name: str, expected_status: str
+):
+    """Test getting the status for the latest case analysis."""
     # GIVEN an analysis
     analysis_store.update_ongoing_analyses()
-    analysis_objs = analysis_store.analyses(case_id=family).first()
-    assert analysis_objs is not None
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_name)
+    assert analysis is not None
 
-    # WHEN checking if the family has an analysis status
-    status = analysis_store.get_latest_analysis_status(case_id=family)
+    # WHEN getting analysis status for case
+    status: Optional[str] = analysis_store.get_latest_analysis_status(case_id=case_name)
 
     # THEN it should return the expected result
-    assert status is expected_status
+    assert status == expected_status
 
 
 @pytest.mark.parametrize(
     "case_id, status",
     [
-        ("blazinginsect", "running"),
-        ("crackpanda", "failed"),
-        ("daringpidgeon", "error"),
-        ("emptydinosaur", "error"),
-        ("escapedgoat", "pending"),
-        ("fancymole", "completed"),
-        ("happycow", "pending"),
-        ("lateraligator", "failed"),
-        ("liberatedunicorn", "error"),
-        ("nicemice", "completed"),
-        ("rarekitten", "canceled"),
-        ("trueferret", "running"),
+        ("blazinginsect", TrailblazerStatus.RUNNING),
+        ("crackpanda", TrailblazerStatus.FAILED),
+        ("daringpidgeon", TrailblazerStatus.ERROR),
+        ("emptydinosaur", TrailblazerStatus.ERROR),
+        ("escapedgoat", TrailblazerStatus.PENDING),
+        ("fancymole", TrailblazerStatus.COMPLETED),
+        ("happycow", TrailblazerStatus.PENDING),
+        ("lateraligator", TrailblazerStatus.FAILED),
+        ("liberatedunicorn", TrailblazerStatus.ERROR),
+        ("nicemice", TrailblazerStatus.COMPLETED),
+        ("rarekitten", TrailblazerStatus.CANCELLED),
+        ("trueferret", TrailblazerStatus.RUNNING),
     ],
 )
-def test_update(analysis_store: MockStore, case_id, status):
+def test_update_run_status(analysis_store: MockStore, case_id: str, status: str):
+    """Test updating an analysis status."""
     # GIVEN an analysis
-    analysis_obj = analysis_store.get_latest_analysis(case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
 
     # WHEN database is updated once
-    analysis_store.update_run_status(analysis_obj.id)
+    analysis_store.update_run_status(analysis_id=analysis.id)
 
-    # THEN analysis status is changed to what is expected
-    assert analysis_obj.status == status
+    # THEN analysis status is updated
+    assert analysis.status == status
 
     # WHEN database is updated a second time
-    analysis_store.update_run_status(analysis_obj.id)
+    analysis_store.update_run_status(analysis_id=analysis.id)
 
-    # THEN the status is still what is expected, and no database errors were raised
-    assert analysis_obj.status == status
+    # THEN the status is unchanged, and no database errors were raised
+    assert analysis.status == status
 
 
-def test_mark_analyses_deleted(analysis_store: MockStore):
-    # GIVEN case_id for a case that is not deleted
-    case_id = "liberatedunicorn"
-    analysis_obj = analysis_store.get_latest_analysis(case_id)
-    assert not analysis_obj.is_deleted
+def test_mark_analyses_deleted(analysis_store: MockStore, ongoing_analysis_case_name: str):
+    """Test marking an ongoing analysis as deleted."""
+    # GIVEN case name for a case that is not deleted
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(
+        case_name=ongoing_analysis_case_name
+    )
+    assert not analysis.is_deleted
 
-    # WHEN running command
-    analysis_store.mark_analyses_deleted(case_id=case_id)
-    analysis_obj = analysis_store.get_latest_analysis(case_id)
+    # WHEN marking analysis as deleted
+    analysis_store.mark_analyses_deleted(case_id=ongoing_analysis_case_name)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(
+        case_name=ongoing_analysis_case_name
+    )
 
     # THEN analysis is marked deleted
-    assert analysis_obj.is_deleted
+    assert analysis.is_deleted
 
 
 def test_update_tower_jobs(analysis_store: MockStore, tower_jobs: List[dict], case_id: str):
     """Assess that jobs are successfully updated when using NF Tower."""
 
     # GIVEN an analysis without failed jobs
-    analysis: Analysis = analysis_store.get_latest_analysis(case_id=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
     assert not analysis.jobs
 
     # WHEN analysis jobs are deleted
@@ -229,7 +236,7 @@ def test_update_tower_jobs(analysis_store: MockStore, tower_jobs: List[dict], ca
     # WHEN jobs are updated
     analysis_store.update_analysis_jobs(analysis=analysis, jobs=tower_jobs[:2])
 
-    # THEN failed jobs should be updated
+    # THEN jobs should be updated
     assert len(analysis.jobs) == 2
 
 
@@ -247,19 +254,19 @@ def test_update_tower_run_status(
     """Assess that an analysis status is successfully updated when using NF Tower."""
 
     # GIVEN an analysis with pending status
-    analysis: Analysis = analysis_store.get_latest_analysis(case_id=case_id)
+    analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_name=case_id)
     assert analysis.status == TrailblazerStatus.PENDING
 
     # WHEN database is updated once
     analysis_store.update_run_status(analysis_id=analysis.id)
 
-    # THEN analysis status is changed to what is expected
+    # THEN analysis status is updated
     assert analysis.status == status
     assert analysis.progress == progress
 
     # WHEN database is updated a second time
     analysis_store.update_run_status(analysis_id=analysis.id)
 
-    # THEN the status is still as before, and no database errors were raised
+    # THEN the status is unchanged, and no database errors were raised
     assert analysis.status == status
     assert analysis.progress == progress

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -2,7 +2,7 @@ import datetime
 import multiprocessing
 import os
 from http import HTTPStatus
-from typing import Dict, List, Mapping, Union
+from typing import Dict, List, Mapping, Optional, Union
 
 from flask import Blueprint, Response, abort, g, jsonify, make_response, request
 from google.auth import jwt
@@ -193,13 +193,15 @@ def post_query_analyses():
 
 @blueprint.route("/get-latest-analysis", methods=["POST"])
 def post_get_latest_analysis():
-    """Return latest analysis entry for specified case"""
-    content = request.json
-    analysis_obj = store.get_latest_analysis(case_id=content.get("case_id"))
-    if analysis_obj:
-        data = stringify_timestamps(analysis_obj.to_dict())
-        return jsonify(**data), 200
-    return jsonify(None), 200
+    """Return latest analysis entry for specified case name."""
+    post_request: Response.json = request.json
+    latest_case_analysis: Optional[Analysis] = store.get_latest_analysis_for_case(
+        case_name=post_request.get("case_id")
+    )
+    if latest_case_analysis:
+        raw_analysis: Dict[str, str] = stringify_timestamps(latest_case_analysis.to_dict())
+        return jsonify(**raw_analysis), HTTPStatus.OK
+    return jsonify(None), HTTPStatus.OK
 
 
 @blueprint.route("/find-analysis", methods=["POST"])

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -84,12 +84,9 @@ class BaseHandler(CoreHandler):
 
         return analysis_query.order_by(self.Analysis.started_at.desc())
 
-    def get_latest_analysis(self, case_id: str) -> Optional[Analysis]:
-        return self.analyses(case_id=case_id).first()
-
     def get_latest_analysis_status(self, case_id: str) -> Optional[str]:
-        """Get the latest analysis status for a case_id"""
-        latest_analysis = self.get_latest_analysis(case_id=case_id)
+        """Get the latest analysis status for a case name."""
+        latest_analysis = self.get_latest_analysis_for_case(case_name=case_id)
         if latest_analysis:
             return latest_analysis.status
 
@@ -126,29 +123,27 @@ class BaseHandler(CoreHandler):
 
     def set_analysis_uploaded(self, case_id: str, uploaded_at: dt.datetime) -> None:
         """Setting analysis uploaded at."""
-        analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.uploaded_at: dt.datetime = uploaded_at
+        analysis: Optional[Analysis] = self.get_latest_analysis_for_case(case_name=case_id)
+        analysis.uploaded_at = uploaded_at
         self.commit()
 
     def set_analysis_status(self, case_id: str, status: str):
         """Setting analysis status."""
-        status = status.lower()
+        status: str = status.lower()
         if status not in set(TrailblazerStatus.statuses()):
             raise ValueError(f"Invalid status. Allowed values are: {TrailblazerStatus.statuses()}")
-        analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.status: str = status
+        analysis: Optional[Analysis] = self.get_latest_analysis_for_case(case_name=case_id)
+        analysis.status = status
         self.commit()
-        LOG.info(f"{analysis_obj.family} - Status set to {status.upper()}")
+        LOG.info(f"{analysis.family} - Status set to {status.upper()}")
 
     def add_comment(self, case_id: str, comment: str):
-        analysis_obj: Analysis = self.get_latest_analysis(case_id=case_id)
-        analysis_obj.comment: str = (
-            " ".join([analysis_obj.comment, comment]) if analysis_obj.comment else comment
+        analysis: Optional[Analysis] = self.get_latest_analysis_for_case(case_name=case_id)
+        analysis.comment: str = (
+            " ".join([analysis.comment, comment]) if analysis.comment else comment
         )
-
         self.commit()
-
-        LOG.info(f"Adding comment {comment} to analysis {analysis_obj.family}")
+        LOG.info(f"Adding comment {comment} to analysis {analysis.family}")
 
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:
         """Delete the analysis output."""

--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -48,6 +48,16 @@ class ReadHandler(BaseHandler_2):
             status=status,
         ).first()
 
+    def get_latest_analysis_for_case(self, case_name: str) -> Optional[Analysis]:
+        """Return the latest analysis for a case."""
+        return apply_analysis_filter(
+            filter_functions=[
+                AnalysisFilter.FILTER_BY_CASE_NAME,
+            ],
+            analyses=self.get_query(table=Analysis),
+            case_name=case_name,
+        ).first()
+
     def get_analysis_with_id(self, analysis_id: int) -> Optional[Analysis]:
         """Get a single analysis by id."""
         return apply_analysis_filter(


### PR DESCRIPTION
## Description

Refactor `get_latest_analysis` and migrate to CRUD.

### Added

- Tests

### Changed

- Refactor `get_latest_analysis` and migrate to CRUD.
- Refactor tests
- Rename case_id fixtures to case_name

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b refactor_get_latest_analysis -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
