### PR TITLE
patch(analysis) Make get_latest_analysis_for_case return the latest case

### DIFF
--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Callable, Dict, List, Optional, Union
 
+from sqlalchemy import asc
+
 from trailblazer.store.base import BaseHandler_2
 from trailblazer.store.filters.analyses_filters import (
     AnalysisFilter,
@@ -56,7 +58,7 @@ class ReadHandler(BaseHandler_2):
             ],
             analyses=self.get_query(table=Analysis),
             case_name=case_name,
-        ).first()
+        ).order_by(Analysis.started_at).first()
 
     def get_analysis_with_id(self, analysis_id: int) -> Optional[Analysis]:
         """Get a single analysis by id."""

--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Callable, Dict, List, Optional, Union
 
-from sqlalchemy import asc
+from sqlalchemy import desc
 
 from trailblazer.store.base import BaseHandler_2
 from trailblazer.store.filters.analyses_filters import (
@@ -60,7 +60,7 @@ class ReadHandler(BaseHandler_2):
                 analyses=self.get_query(table=Analysis),
                 case_name=case_name,
             )
-            .order_by(Analysis.started_at)
+            .order_by(desc(Analysis.started_at))
             .first()
         )
 

--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -52,13 +52,17 @@ class ReadHandler(BaseHandler_2):
 
     def get_latest_analysis_for_case(self, case_name: str) -> Optional[Analysis]:
         """Return the latest analysis for a case."""
-        return apply_analysis_filter(
-            filter_functions=[
-                AnalysisFilter.FILTER_BY_CASE_NAME,
-            ],
-            analyses=self.get_query(table=Analysis),
-            case_name=case_name,
-        ).order_by(Analysis.started_at).first()
+        return (
+            apply_analysis_filter(
+                filter_functions=[
+                    AnalysisFilter.FILTER_BY_CASE_NAME,
+                ],
+                analyses=self.get_query(table=Analysis),
+                case_name=case_name,
+            )
+            .order_by(Analysis.started_at)
+            .first()
+        )
 
     def get_analysis_with_id(self, analysis_id: int) -> Optional[Analysis]:
         """Get a single analysis by id."""


### PR DESCRIPTION
## Description
The `get_latest_analysis_for_case` function is currently returning the oldest analysis, which is causing bugs in production.
This PR adds a descending ordering.

### Fixed

- `get_latest_analysis_for_case` now returns the latest analysis



### This [version](https://semver.org/) is a

- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
