### PR TITLE
Refactor update_analysis_from_slurm_output

### DIFF
--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -20,38 +20,6 @@ def test_setup_db(store: MockStore):
     assert store.engine.table_names()
 
 
-def test_update_analysis_from_slurm_run_status(
-    analysis_store: MockStore,
-    squeue_stream_jobs: str,
-    mocker,
-    ongoing_analysis_case_id: str,
-    slurm_squeue_output: Dict[str, str],
-):
-    """Test updating analysis jobs when given squeue results."""
-    # GIVEN an analysis and a squeue stream
-    analysis: Analysis = analysis_store.get_query(table=Analysis).first()
-    assert not analysis.jobs
-
-    # GIVEN SLURM squeue output for an analysis
-    mocker.patch(
-        FUNC_GET_SLURM_SQUEUE_OUTPUT_PATH,
-        return_value=subprocess.check_output(
-            ["cat", slurm_squeue_output.get(ongoing_analysis_case_id)]
-        ).decode(CharacterFormat.UNICODE_TRANSFORMATION_FORMAT_8),
-    )
-
-    # WHEN updating the analysis
-    analysis_store.update_analysis_from_slurm_output(
-        analysis_id=analysis.id, analysis_host="a_host"
-    )
-    updated_analysis: Analysis = analysis_store.get_analysis(
-        case_id=analysis.family, started_at=analysis.started_at, status=TrailblazerStatus.RUNNING
-    )
-
-    # THEN it should update the analysis jobs
-    assert updated_analysis.jobs
-
-
 @pytest.mark.parametrize(
     "case_id, status",
     [

--- a/trailblazer/store/api.py
+++ b/trailblazer/store/api.py
@@ -100,22 +100,6 @@ class BaseHandler(CoreHandler):
                 analysis_id=analysis_id, analysis_host=analysis_host
             )
 
-    def update_analysis_from_slurm_output(
-        self, analysis_id: int, analysis_host: Optional[str] = False
-    ) -> None:
-        """Query SLURM for entries related to given analysis, and update the analysis in the database."""
-        analysis: Optional[Analysis] = self.get_analysis_with_id(analysis_id=analysis_id)
-        try:
-            self._update_analysis_from_slurm_squeue_output(
-                analysis=analysis, analysis_host=analysis_host
-            )
-        except Exception as exception:
-            LOG.error(
-                f"Error updating analysis for: case - {analysis.family} : {exception.__class__.__name__}"
-            )
-            analysis.status = TrailblazerStatus.ERROR
-            self.commit()
-
     @staticmethod
     def query_tower(config_file: str, case_id: str) -> TowerAPI:
         """Parse a config file to extract a NF Tower workflow ID and return a TowerAPI.

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -79,6 +79,22 @@ class UpdateHandler(BaseHandler_2):
         analysis.logged_at = datetime.now()
         self.commit()
 
+    def update_analysis_from_slurm_output(
+        self, analysis_id: int, analysis_host: Optional[str] = False
+    ) -> None:
+        """Query SLURM for entries related to given analysis, and update the analysis in the database."""
+        analysis: Optional[Analysis] = self.get_analysis_with_id(analysis_id=analysis_id)
+        try:
+            self._update_analysis_from_slurm_squeue_output(
+                analysis=analysis, analysis_host=analysis_host
+            )
+        except Exception as exception:
+            LOG.error(
+                f"Error updating analysis for: case - {analysis.family} : {exception.__class__.__name__}"
+            )
+            analysis.status = TrailblazerStatus.ERROR
+            self.commit()
+
     def update_case_analyses_as_deleted(self, case_id: str) -> Optional[List[Analysis]]:
         """Mark analyses connected to a case as deleted."""
         analyses: Optional[List[Analysis]] = self.get_analyses_for_case(case_id=case_id)


### PR DESCRIPTION
## Description

Refactor update_analysis_from_slurm_output

### Changed

- Reafctor update_analysis_from_slurm_output and migrate to CRUD

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
