### PR TITLE
Cancel tower analysis

### DIFF
--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -221,7 +221,7 @@ def test_cancel_with_ongoing_analysis(
     assert result.exit_code == process_exit_success
 
     # THEN log should inform of successful cancellation
-    assert "all ongoing jobs cancelled successfully" in caplog.text
+    assert "cancelled successfully" in caplog.text
     assert "Cancelling" in caplog.text
 
     # THEN job id from squeue output will be cancelled

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -151,7 +151,7 @@ def test_cancel_ongoing_tower_analysis(analysis_store: MockStore, caplog, mocker
     analysis_store.cancel_ongoing_analysis(analysis_id=analysis.id)
 
     # THEN log should inform of successful cancellation
-    assert f"Cancelling Tower workflow for {case_id}"
+    assert f"Cancelling Tower workflow for {case_id}" in caplog.text
     assert "cancelled successfully!" in caplog.text
 
     # THEN comment should be added

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -153,10 +153,10 @@ def test_cancel_ongoing_tower_analysis(analysis_store: MockStore, caplog, mocker
 
     # THEN log should inform of successful cancellation
     assert f"Cancelling Tower workflow for {case_id}" in caplog.text
-    assert "cancelled successfully!" in caplog.text
-
-    # THEN comment should be added
-    assert "Analysis cancelled manually by" in analysis.comment
+    # assert "cancelled successfully!" in caplog.text
+    #
+    # # THEN comment should be added
+    # assert "Analysis cancelled manually by" in analysis.comment
 
 
 def test_cancel_ongoing_analysis_when_no_analysis(

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -158,9 +158,6 @@ def test_cancel_ongoing_tower_analysis(analysis_store: MockStore, caplog, mocker
     # THEN comment should be added
     assert "Analysis cancelled manually by" in analysis.comment
 
-    # THEN analysis status should be updated
-    assert TrailblazerStatus.CANCELLED == analysis.status
-
 
 def test_cancel_ongoing_analysis_when_no_analysis(
     analysis_id_does_not_exist: int, analysis_store: MockStore, caplog, tower_jobs: List[dict]

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -153,10 +153,10 @@ def test_cancel_ongoing_tower_analysis(analysis_store: MockStore, caplog, mocker
 
     # THEN log should inform of successful cancellation
     assert f"Cancelling Tower workflow for {case_id}" in caplog.text
-    # assert "cancelled successfully!" in caplog.text
-    #
-    # # THEN comment should be added
-    # assert "Analysis cancelled manually by" in analysis.comment
+    assert "cancelled successfully!" in caplog.text
+
+    # THEN comment should be added
+    assert "Analysis cancelled manually by" in analysis.comment
 
 
 def test_cancel_ongoing_analysis_when_no_analysis(

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -135,7 +135,7 @@ def test_cancel_ongoing_slurm_analysis(
     assert "Analysis cancelled manually by" in analysis.comment
 
     # THEN analysis status should be updated
-    assert TrailblazerStatus.CANCELLED in analysis.status
+    assert TrailblazerStatus.CANCELLED == analysis.status
 
 
 def test_cancel_ongoing_tower_analysis(analysis_store: MockStore, caplog, mocker, case_id: str):
@@ -158,7 +158,7 @@ def test_cancel_ongoing_tower_analysis(analysis_store: MockStore, caplog, mocker
     assert "Analysis cancelled manually by" in analysis.comment
 
     # THEN analysis status should be updated
-    assert TrailblazerStatus.CANCELLED in analysis.status
+    assert TrailblazerStatus.CANCELLED == analysis.status
 
 
 def test_cancel_ongoing_analysis_when_no_analysis(

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -118,7 +118,7 @@ class TowerApiClient:
             url = self.build_url(endpoint=self.workflow_endpoint)
             return TowerWorkflowResponse(**self.send_request(url=url))
 
-    def cancel(self) -> dict:
+    def send_cancel_request(self) -> dict:
         """Send a POST request to cancel a workflow."""
         if self.meets_requirements:
             url: str = self.build_url(endpoint=self.cancel_endpoint)
@@ -234,4 +234,4 @@ class TowerAPI:
 
     def cancel(self) -> None:
         """Cancel a workflow."""
-        self.tower_client.cancel()
+        self.tower_client.send_cancel_request()

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -118,8 +118,7 @@ class TowerApiClient:
             url = self.build_url(endpoint=self.workflow_endpoint)
             return TowerWorkflowResponse(**self.send_request(url=url))
 
-    @property
-    def cancel(self) -> None:
+    def cancel(self) -> dict:
         """Send a POST request to cancel a workflow."""
         if self.meets_requirements:
             url: str = self.build_url(endpoint=self.cancel_endpoint)
@@ -231,7 +230,6 @@ class TowerAPI:
             elapsed=int(task.duration / 60),
         )
 
-    @property
     def cancel(self) -> None:
         """Cancel a workflow."""
-        self.tower_client.cancel
+        self.tower_client.cancel()

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -30,6 +30,7 @@ class TowerApiClient:
         self.tower_api_endpoint: str = os.environ.get("TOWER_API_ENDPOINT", None)
         self.workflow_endpoint: str = f"workflow/{self.workflow_id}"
         self.tasks_endpoint: str = f"{self.workflow_endpoint}/tasks"
+        self.cancel_endpoint: str = f"{self.workflow_endpoint}/cancel"
 
     @property
     def headers(self) -> dict:
@@ -101,6 +102,13 @@ class TowerApiClient:
         if self.meets_requirements:
             url = self.build_url(endpoint=self.workflow_endpoint)
             return TowerWorkflowResponse(**self.send_request(url=url))
+
+    @property
+    def cancel(self) -> None:
+        """Send a POST request to cancel a workflow."""
+        if self.meets_requirements:
+            url: str = self.build_url(endpoint=self.cancel_endpoint)
+            self.post_request(url=url)
 
 
 class TowerAPI:
@@ -207,3 +215,8 @@ class TowerAPI:
             started_at=task.start,
             elapsed=int(task.duration / 60),
         )
+
+    @property
+    def cancel(self) -> None:
+        """Cancel a workflow."""
+        self.tower_client.cancel

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -14,7 +14,7 @@ from trailblazer.apps.tower.models import (
     TowerTaskResponse,
     TowerWorkflowResponse,
 )
-from trailblazer.constants import TOWER_STATUS, TrailblazerStatus
+from trailblazer.constants import TOWER_WORKFLOW_STATUS, TrailblazerStatus
 from trailblazer.exc import TrailblazerError
 
 LOG = logging.getLogger(__name__)
@@ -162,7 +162,9 @@ class TowerAPI:
     @property
     def status(self) -> str:
         """Returns the status of an analysis (also called workflow in NF Tower)."""
-        status: str = TOWER_STATUS.get(self.response.workflow.status, TrailblazerStatus.ERROR.value)
+        status: str = TOWER_WORKFLOW_STATUS.get(
+            self.response.workflow.status, TrailblazerStatus.ERROR.value
+        )
 
         # If the whole workflow (analysis) is completed set it as QC instead of COMPLETE
         if status == TrailblazerStatus.COMPLETED:

--- a/trailblazer/apps/tower/api.py
+++ b/trailblazer/apps/tower/api.py
@@ -76,7 +76,7 @@ class TowerApiClient:
 
         return response.json()
 
-    def post_request(self, url: str, data: dict = {}) -> dict:
+    def post_request(self, url: str, data: dict = {}) -> None:
         """Send data via POST request and return response."""
         try:
             response = requests.post(
@@ -88,7 +88,6 @@ class TowerApiClient:
         except (MissingSchema, HTTPError, ConnectionError) as error:
             LOG.error(f"Request failed for url {url}: Error: {error}\n")
             raise TrailblazerError
-        return response.json()
 
     @property
     def meets_requirements(self) -> bool:
@@ -118,7 +117,7 @@ class TowerApiClient:
             url = self.build_url(endpoint=self.workflow_endpoint)
             return TowerWorkflowResponse(**self.send_request(url=url))
 
-    def send_cancel_request(self) -> dict:
+    def send_cancel_request(self) -> None:
         """Send a POST request to cancel a workflow."""
         if self.meets_requirements:
             url: str = self.build_url(endpoint=self.cancel_endpoint)

--- a/trailblazer/apps/tower/models.py
+++ b/trailblazer/apps/tower/models.py
@@ -3,7 +3,13 @@ from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from trailblazer.constants import TOWER_PROCESS_STATUS, TOWER_WORKFLOW_STATUS, TrailblazerStatus
+from trailblazer.constants import (
+    TOWER_PROCESS_STATUS,
+    TOWER_TASK_STATUS,
+    TOWER_WORKFLOW_STATUS,
+    SlurmJobStatus,
+    TrailblazerStatus,
+)
 from trailblazer.utils.datetime import tower_datetime_converter
 
 SCALE_TO_MILLISEC: int = 1000
@@ -72,7 +78,7 @@ class TowerTask(BaseModel):
     @field_validator("status")
     @classmethod
     def set_status(cls, raw_status) -> str:
-        return TOWER_WORKFLOW_STATUS.get(raw_status)
+        return TOWER_TASK_STATUS.get(raw_status)
 
     @field_validator("start", "dateCreated", "lastUpdated")
     @classmethod
@@ -87,7 +93,7 @@ class TowerTask(BaseModel):
     @property
     def is_complete(cls) -> bool:
         """Returns if the process succeded."""
-        return cls.status == TrailblazerStatus.COMPLETED
+        return cls.status == SlurmJobStatus.COMPLETED
 
 
 class TowerProcess(BaseModel):

--- a/trailblazer/apps/tower/models.py
+++ b/trailblazer/apps/tower/models.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from trailblazer.constants import TOWER_PROCESS_STATUS, TOWER_STATUS, TrailblazerStatus
+from trailblazer.constants import TOWER_PROCESS_STATUS, TOWER_WORKFLOW_STATUS, TrailblazerStatus
 from trailblazer.utils.datetime import tower_datetime_converter
 
 SCALE_TO_MILLISEC: int = 1000
@@ -72,7 +72,7 @@ class TowerTask(BaseModel):
     @field_validator("status")
     @classmethod
     def set_status(cls, raw_status) -> str:
-        return TOWER_STATUS.get(raw_status)
+        return TOWER_WORKFLOW_STATUS.get(raw_status)
 
     @field_validator("start", "dateCreated", "lastUpdated")
     @classmethod

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -127,12 +127,12 @@ TOWER_WORKFLOW_STATUS: Dict[str, str] = {
 
 
 TOWER_PROCESS_STATUS: Dict[str, str] = {
-    "submitted": SlurmJobStatus.PENDING,
-    "pending": SlurmJobStatus.PENDING,
-    "running": SlurmJobStatus.RUNNING,
-    "cached": SlurmJobStatus.COMPLETED,
-    "succeeded": SlurmJobStatus.COMPLETED,
-    "failed": SlurmJobStatus.FAILED,
+    "submitted": TrailblazerStatus.PENDING,
+    "pending": TrailblazerStatus.PENDING,
+    "running": TrailblazerStatus.RUNNING,
+    "cached": TrailblazerStatus.COMPLETED,
+    "succeeded": TrailblazerStatus.COMPLETED,
+    "failed": TrailblazerStatus.FAILED,
 }
 
 

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -112,7 +112,7 @@ class TrailblazerStatusColor(str, Enum):
     RUNNING: str = "blue"
 
 
-TOWER_STATUS: Dict[str, str] = {
+TOWER_WORKFLOW_STATUS: Dict[str, str] = {
     "ABORTED": TrailblazerStatus.FAILED,
     "CACHED": TrailblazerStatus.COMPLETED,
     "CANCELLED": TrailblazerStatus.CANCELLED,

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -115,7 +115,7 @@ class TrailblazerStatusColor(str, Enum):
 TOWER_STATUS: Dict[str, str] = {
     "ABORTED": TrailblazerStatus.FAILED,
     "CACHED": TrailblazerStatus.COMPLETED,
-    "CANCELLED": TrailblazerStatus.FAILED,
+    "CANCELLED": TrailblazerStatus.CANCELLED,
     "COMPLETED": TrailblazerStatus.COMPLETED,
     "FAILED": TrailblazerStatus.FAILED,
     "NEW": TrailblazerStatus.PENDING,
@@ -127,10 +127,24 @@ TOWER_STATUS: Dict[str, str] = {
 
 
 TOWER_PROCESS_STATUS: Dict[str, str] = {
-    "submitted": TrailblazerStatus.PENDING,
-    "pending": TrailblazerStatus.PENDING,
-    "running": TrailblazerStatus.RUNNING,
-    "cached": TrailblazerStatus.COMPLETED,
-    "succeeded": TrailblazerStatus.COMPLETED,
-    "failed": TrailblazerStatus.FAILED,
+    "submitted": SlurmJobStatus.PENDING,
+    "pending": SlurmJobStatus.PENDING,
+    "running": SlurmJobStatus.RUNNING,
+    "cached": SlurmJobStatus.COMPLETED,
+    "succeeded": SlurmJobStatus.COMPLETED,
+    "failed": SlurmJobStatus.FAILED,
+}
+
+
+TOWER_TASK_STATUS: Dict[str, str] = {
+    "ABORTED": SlurmJobStatus.FAILED,
+    "CACHED": SlurmJobStatus.COMPLETED,
+    "CANCELLED": SlurmJobStatus.CANCELLED,
+    "COMPLETED": SlurmJobStatus.COMPLETED,
+    "FAILED": SlurmJobStatus.FAILED,
+    "NEW": SlurmJobStatus.PENDING,
+    "RUNNING": SlurmJobStatus.RUNNING,
+    "SUBMITTED": SlurmJobStatus.PENDING,
+    "SUCCEEDED": SlurmJobStatus.COMPLETED,
+    "UNKNOWN": SlurmJobStatus.FAILED,
 }

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -121,9 +121,9 @@ class UpdateHandler(BaseHandler_2):
             self.cancel_tower_analysis(analysis=analysis)
         else:
             self.cancel_slurm_analysis(analysis=analysis, analysis_host=analysis_host)
-            self.update_run_status(analysis_id=analysis_id, analysis_host=analysis_host)
-            analysis.status = TrailblazerStatus.CANCELLED
         LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")
+        self.update_run_status(analysis_id=analysis_id, analysis_host=analysis_host)
+        analysis.status = TrailblazerStatus.CANCELLED
         analysis.comment = (
             f"Analysis cancelled manually by user:"
             f" {(self.get_user(email=email).name if self.get_user(email=email) else (email or 'Unknown'))}!"

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -119,14 +119,14 @@ class UpdateHandler(BaseHandler_2):
     def cancel_slurm_analysis(
         self, analysis: Analysis, analysis_host: Optional[str] = None
     ) -> None:
-        """Cancel slurm analysis by cancelling all associated slurm jobs."""
+        """Cancel SLURM analysis by cancelling all associated SLURM jobs."""
         for job in analysis.jobs:
             if job.status in SlurmJobStatus.ongoing_statuses():
                 LOG.info(f"Cancelling job {job.slurm_id} - {job.name}")
                 cancel_slurm_job(analysis_host=analysis_host, slurm_id=job.slurm_id)
 
     def cancel_tower_analysis(self, analysis: Analysis) -> None:
-        """Cancel a NF-Tower analysis."""
+        """Cancel a NF-Tower analysis. Associated jobs are cancelled by Tower."""
         LOG.info(f"Cancelling Tower workflow for {analysis.family}")
         self.query_tower(config_file=analysis.config_path, case_id=analysis.family).cancel
 

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -118,7 +118,10 @@ class UpdateHandler(BaseHandler_2):
         if analysis.status not in TrailblazerStatus.ongoing_statuses():
             raise TrailblazerError(f"Analysis {analysis_id} is not running")
         if analysis.workflow_manager == WorkflowManager.TOWER.value:
-            self.cancel_tower_analysis(analysis=analysis)
+            try:
+                self.cancel_tower_analysis(analysis=analysis)
+            except TrailblazerError:
+                return
         else:
             self.cancel_slurm_analysis(analysis=analysis, analysis_host=analysis_host)
         LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -11,7 +11,7 @@ from trailblazer.apps.slurm.api import (
     reformat_squeue_result_job_step,
 )
 from trailblazer.apps.slurm.models import SqueueResult
-from trailblazer.constants import SlurmJobStatus, TrailblazerStatus
+from trailblazer.constants import SlurmJobStatus, TrailblazerStatus, WorkflowManager
 from trailblazer.exc import MissingAnalysis, TrailblazerError
 from trailblazer.store.base import BaseHandler_2
 from trailblazer.store.models import Analysis, Job, User
@@ -101,13 +101,13 @@ class UpdateHandler(BaseHandler_2):
             raise MissingAnalysis(f"Analysis {analysis_id} does not exist")
         if analysis.status not in TrailblazerStatus.ongoing_statuses():
             raise TrailblazerError(f"Analysis {analysis_id} is not running")
-        for job in analysis.jobs:
-            if job.status in SlurmJobStatus.ongoing_statuses():
-                LOG.info(f"Cancelling job {job.slurm_id} - {job.name}")
-                cancel_slurm_job(analysis_host=analysis_host, slurm_id=job.slurm_id)
-        LOG.info(
-            f"Case {analysis.family} - Analysis {analysis_id}: all ongoing jobs cancelled successfully!"
-        )
+        if analysis.workflow_manager == WorkflowManager.TOWER.value:
+            LOG.info("TOWER ANALYSIS ----- ")
+            self.cancel_tower_analysis(analysis=analysis)
+        else:
+            LOG.info("SLURM ANALYSIS ----- ")
+            self.cancel_slurm_analysis(analysis=analysis, analysis_host=analysis_host)
+        LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")
         self.update_run_status(analysis_id=analysis_id, analysis_host=analysis_host)
         analysis.status = TrailblazerStatus.CANCELLED
         analysis.comment = (
@@ -115,6 +115,20 @@ class UpdateHandler(BaseHandler_2):
             f" {(self.get_user(email=email).name if self.get_user(email=email) else (email or 'Unknown'))}!"
         )
         self.commit()
+
+    def cancel_slurm_analysis(
+        self, analysis: Analysis, analysis_host: Optional[str] = None
+    ) -> None:
+        """Cancel slurm analysis by cancelling all associated slurm jobs."""
+        for job in analysis.jobs:
+            if job.status in SlurmJobStatus.ongoing_statuses():
+                LOG.info(f"Cancelling job {job.slurm_id} - {job.name}")
+                cancel_slurm_job(analysis_host=analysis_host, slurm_id=job.slurm_id)
+
+    def cancel_tower_analysis(self, analysis: Analysis) -> None:
+        """Cancel a NF-Tower analysis."""
+        LOG.info(f"Cancelling Tower workflow for {analysis.family}")
+        self.query_tower(config_file=analysis.config_path, case_id=analysis.family).cancel
 
     def update_analysis_status(self, case_id: str, status: str):
         """Setting analysis status."""

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -123,12 +123,12 @@ class UpdateHandler(BaseHandler_2):
             self.cancel_slurm_analysis(analysis=analysis, analysis_host=analysis_host)
             self.update_run_status(analysis_id=analysis_id, analysis_host=analysis_host)
             analysis.status = TrailblazerStatus.CANCELLED
-            LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")
-            analysis.comment = (
-                f"Analysis cancelled manually by user:"
-                f" {(self.get_user(email=email).name if self.get_user(email=email) else (email or 'Unknown'))}!"
-            )
-            self.commit()
+        LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")
+        analysis.comment = (
+            f"Analysis cancelled manually by user:"
+            f" {(self.get_user(email=email).name if self.get_user(email=email) else (email or 'Unknown'))}!"
+        )
+        self.commit()
 
     def cancel_slurm_analysis(
         self, analysis: Analysis, analysis_host: Optional[str] = None

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -118,10 +118,8 @@ class UpdateHandler(BaseHandler_2):
         if analysis.status not in TrailblazerStatus.ongoing_statuses():
             raise TrailblazerError(f"Analysis {analysis_id} is not running")
         if analysis.workflow_manager == WorkflowManager.TOWER.value:
-            LOG.info("TOWER ANALYSIS ----- ")
             self.cancel_tower_analysis(analysis=analysis)
         else:
-            LOG.info("SLURM ANALYSIS ----- ")
             self.cancel_slurm_analysis(analysis=analysis, analysis_host=analysis_host)
         LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")
         self.update_run_status(analysis_id=analysis_id, analysis_host=analysis_host)

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -123,12 +123,12 @@ class UpdateHandler(BaseHandler_2):
             self.cancel_slurm_analysis(analysis=analysis, analysis_host=analysis_host)
             self.update_run_status(analysis_id=analysis_id, analysis_host=analysis_host)
             analysis.status = TrailblazerStatus.CANCELLED
-        LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")
-        analysis.comment = (
-            f"Analysis cancelled manually by user:"
-            f" {(self.get_user(email=email).name if self.get_user(email=email) else (email or 'Unknown'))}!"
-        )
-        self.commit()
+            LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")
+            analysis.comment = (
+                f"Analysis cancelled manually by user:"
+                f" {(self.get_user(email=email).name if self.get_user(email=email) else (email or 'Unknown'))}!"
+            )
+            self.commit()
 
     def cancel_slurm_analysis(
         self, analysis: Analysis, analysis_host: Optional[str] = None

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -121,9 +121,9 @@ class UpdateHandler(BaseHandler_2):
             self.cancel_tower_analysis(analysis=analysis)
         else:
             self.cancel_slurm_analysis(analysis=analysis, analysis_host=analysis_host)
+            self.update_run_status(analysis_id=analysis_id, analysis_host=analysis_host)
+            analysis.status = TrailblazerStatus.CANCELLED
         LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")
-        self.update_run_status(analysis_id=analysis_id, analysis_host=analysis_host)
-        analysis.status = TrailblazerStatus.CANCELLED
         analysis.comment = (
             f"Analysis cancelled manually by user:"
             f" {(self.get_user(email=email).name if self.get_user(email=email) else (email or 'Unknown'))}!"
@@ -142,7 +142,7 @@ class UpdateHandler(BaseHandler_2):
     def cancel_tower_analysis(self, analysis: Analysis) -> None:
         """Cancel a NF-Tower analysis. Associated jobs are cancelled by Tower."""
         LOG.info(f"Cancelling Tower workflow for {analysis.family}")
-        self.query_tower(config_file=analysis.config_path, case_id=analysis.family).cancel
+        self.query_tower(config_file=analysis.config_path, case_id=analysis.family).cancel()
 
     def update_analysis_status(self, case_id: str, status: str):
         """Setting analysis status."""

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -118,10 +118,7 @@ class UpdateHandler(BaseHandler_2):
         if analysis.status not in TrailblazerStatus.ongoing_statuses():
             raise TrailblazerError(f"Analysis {analysis_id} is not running")
         if analysis.workflow_manager == WorkflowManager.TOWER.value:
-            try:
-                self.cancel_tower_analysis(analysis=analysis)
-            except TrailblazerError:
-                return
+            self.cancel_tower_analysis(analysis=analysis)
         else:
             self.cancel_slurm_analysis(analysis=analysis, analysis_host=analysis_host)
         LOG.info(f"Case {analysis.family} - Analysis {analysis.id}: cancelled successfully!")


### PR DESCRIPTION
## Description

Closes: https://github.com/Clinical-Genomics/trailblazer/issues/226

### Changed

- `cancel` supports NF-Tower cases

### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] activate stage: `us`
- [x] request trailblazer-stage on hasta: `paxa`
- [x] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b  cancel_tower -a
    ```

### How to test
- [x] Cancel not ongoing analysis: `trailblazer cancel 279435`. It should raise the following error: `TrailblazerError: Analysis 279435 is not running`
- [x] Cancel ongoing analysis with failed tower response: `trailblazer cancel 279435`. It should raise the following error: `Request failed for url {url}: Error: {error}`
- [x] Cancel ongoing analysis: `trailblazer cancel 271983`. It complete successfully with the following message: `Analysis 279435: cancelled successfully!`


## Review
- [X] tests executed by EFC
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
