### PR TITLE
feat(end-point): Remove unused query-analyses

### DIFF
--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -177,29 +177,6 @@ def delete(analysis_id):
 # NOT for use with GUI (for now)
 
 
-@blueprint.route("/query-analyses", methods=["POST"])
-def post_query_analyses():
-    """Return list of analyses matching the query terms."""
-    post_request: Response.json = request.json
-    query_analyses: List[Analysis] = store.analyses(
-        before=datetime.strptime(post_request.get("before"), TRAILBLAZER_TIME_STAMP).date()
-        if post_request.get("before")
-        else None,
-        case_id=post_request.get("case_id"),
-        data_analysis=post_request.get("data_analysis"),
-        deleted=post_request.get("deleted"),
-        family=post_request.get("family"),
-        is_visible=post_request.get("visible"),
-        query=post_request.get("query"),
-        status=post_request.get("status"),
-        temp=post_request.get("temp"),
-    )
-    raw_analyses: List[Dict[str, str]] = [
-        stringify_timestamps(analysis_obj.to_dict()) for analysis_obj in query_analyses
-    ]
-    return jsonify(*raw_analyses), HTTPStatus.OK
-
-
 @blueprint.route("/get-latest-analysis", methods=["POST"])
 def post_get_latest_analysis():
     """Return latest analysis entry for specified case id."""


### PR DESCRIPTION
## Description

Remove unused query-analyses end point

### Changed

- Remove unused query-analyses end point

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
