### PR TITLE
Upgrade sqlalchemy to 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Click
-SQLAlchemy<1.4
+SQLAlchemy<2
 alembic
 coloredlogs
 marshmallow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Click
-SQLAlchemy<2
+SQLAlchemy
 alembic
 coloredlogs
 marshmallow

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -390,7 +390,6 @@ def test_update_analysis_comment_when_existing(analysis_store: MockStore, case_i
 
 def test_update_analysis_from_slurm_run_status(
     analysis_store: MockStore,
-    squeue_stream_jobs: str,
     mocker,
     ongoing_analysis_case_id: str,
     slurm_squeue_output: Dict[str, str],

--- a/trailblazer/apps/tower/models.py
+++ b/trailblazer/apps/tower/models.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, ConfigDict, field_validator
 from trailblazer.constants import (
     TOWER_PROCESS_STATUS,
     TOWER_TASK_STATUS,
-    TOWER_WORKFLOW_STATUS,
     SlurmJobStatus,
     TrailblazerStatus,
 )
@@ -135,7 +134,7 @@ class TowerProcess(BaseModel):
     @property
     def status(cls) -> str:
         for status_flag in TOWER_PROCESS_STATUS.keys():
-            if cls.dict().get(status_flag, 0):
+            if cls.model_dump().get(status_flag, 0):
                 return TOWER_PROCESS_STATUS.get(status_flag)
         return TrailblazerStatus.ERROR
 

--- a/trailblazer/store/database.py
+++ b/trailblazer/store/database.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from sqlalchemy import inspect
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 SESSION: Optional[Session] = None
 ENGINE: Optional[Engine] = None

--- a/trailblazer/store/database.py
+++ b/trailblazer/store/database.py
@@ -14,8 +14,8 @@ Model = declarative_base()
 
 def initialize_database(db_uri: str) -> None:
     global SESSION, ENGINE
-    ENGINE = create_engine(db_uri, pool_pre_ping=True)
-    session_factory = sessionmaker(ENGINE)
+    ENGINE = create_engine(db_uri, pool_pre_ping=True, future=True)
+    session_factory = sessionmaker(ENGINE, future=True)
     SESSION = scoped_session(session_factory)
 
 

--- a/trailblazer/store/database.py
+++ b/trailblazer/store/database.py
@@ -14,8 +14,8 @@ Model = declarative_base()
 
 def initialize_database(db_uri: str) -> None:
     global SESSION, ENGINE
-    ENGINE = create_engine(db_uri, pool_pre_ping=True, future=True)
-    session_factory = sessionmaker(ENGINE, future=True)
+    ENGINE = create_engine(db_uri, pool_pre_ping=True)
+    session_factory = sessionmaker(ENGINE)
     SESSION = scoped_session(session_factory)
 
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -41,7 +41,7 @@ class User(Model):
     is_archived = Column(types.Boolean, default=False)
     name = Column(types.String(128))
 
-    runs = orm.relationship("Analysis", backref="user", cascade_backrefs=False)
+    runs = orm.relationship("Analysis", backref="user")
 
     @property
     def first_name(self) -> str:
@@ -94,7 +94,7 @@ class Analysis(Model):
         types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM.value
     )
 
-    jobs = orm.relationship("Job", cascade="all,delete", backref="analysis", cascade_backrefs=False)
+    jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
 
     @property
     def has_ongoing_status(self) -> bool:

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -41,7 +41,7 @@ class User(Model):
     is_archived = Column(types.Boolean, default=False)
     name = Column(types.String(128))
 
-    runs = orm.relationship("Analysis", backref="user")
+    runs = orm.relationship("Analysis", backref="user", cascade_backrefs=False)
 
     @property
     def first_name(self) -> str:
@@ -94,7 +94,7 @@ class Analysis(Model):
         types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM.value
     )
 
-    jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
+    jobs = orm.relationship("Job", cascade="all,delete", backref="analysis", cascade_backrefs=False)
 
     @property
     def has_ongoing_status(self) -> bool:


### PR DESCRIPTION
## Description
This PR upgrades sqlalchemy to 2.0. Very painless 😄 

### Testing
- [ ] Deploy to web stage and verify data can be retrieved and updated
- [ ] Deploy to hasta and verify that a user can be created and that the scan command works

### Fixed
- Upgrade sqlalchemy to the latest version

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
