### PR TITLE
Commit transactions before sending response

### DIFF
--- a/tests/store/crud/test_delete.py
+++ b/tests/store/crud/test_delete.py
@@ -21,13 +21,11 @@ def test_delete_analysis_jobs(analysis_store: MockStore, tower_jobs: List[dict],
 
     # WHEN jobs are updated
     analysis_store.update_analysis_jobs(analysis=analysis, jobs=tower_jobs[:2])
-    session.commit()
 
     assert analysis.jobs
 
     # WHEN jobs are deleted
     analysis_store.delete_analysis_jobs(analysis=analysis)
-    session.commit()
 
     # THEN analysis object should have no jobs
     assert not analysis.jobs
@@ -44,7 +42,6 @@ def test_delete_analysis(analysis_store: MockStore, case_id: str):
 
     # WHEN deleting analysis
     analysis_store.delete_analysis(analysis_id=analysis.id)
-    session.commit()
 
     # THEN analysis object should be deleted
     analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_id=case_id)
@@ -62,7 +59,6 @@ def test_delete_analysis_with_force(analysis_store: MockStore, case_id: str):
 
     # WHEN deleting analysis
     analysis_store.delete_analysis(analysis_id=analysis.id, force=True)
-    session.commit()
 
     # THEN analysis object should be deleted
     analysis: Optional[Analysis] = analysis_store.get_latest_analysis_for_case(case_id=case_id)

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -35,7 +35,7 @@ class DatabaseResource:
     def __enter__(self):
         initialize_database(self.db_uri)
 
-    def __exit__(self _, __, ___):
+    def __exit__(self, _, __, ___):
         session: scoped_session = get_session()
         session.remove()
 

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -32,7 +32,7 @@ class DatabaseResource:
     def __init__(self, db_uri: str):
         self.db_uri = db_uri
 
-    def __enter__(self):
+    def __enter__(self, _, __, ___):
         initialize_database(self.db_uri)
 
     def __exit__(self):

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 import click
 import coloredlogs
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import scoped_session
 
 import trailblazer
 from trailblazer.cli.utils.ls_helper import _get_ls_analysis_message
@@ -23,9 +23,9 @@ LOG = logging.getLogger(__name__)
 LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
 
 
-class SessionContextManager:
+class DatabaseResource:
     """
-    Remove the database session to ensure database resources are released when a
+    Setup the database and ensure resources are released when the
     CLI command has been processed.
     """
 
@@ -35,19 +35,9 @@ class SessionContextManager:
     def __enter__(self):
         initialize_database(self.db_uri)
 
-    def __exit__(self, exc_type, exc_value, tb):
-        session: Session = get_session()
-        try:
-            if exc_type is not None:
-                LOG.error(f"Rolling back due to exception when processing command: {exc_value}")
-                session.rollback()
-            else:
-                session.commit()
-        except Exception as e:
-            LOG.error(f"Failed to commit transaction after processing command, rolling back: {e}")
-            session.rollback()
-        finally:
-            session.remove()
+    def __exit__(self):
+        session: scoped_session = get_session()
+        session.remove()
 
 
 @click.group()
@@ -76,7 +66,7 @@ def base(
         **ReadFile.get_content_from_file(file_format=FileFormat.YAML, file_path=Path(config.name))
     )
     context.obj = dict(validated_config)
-    context.with_resource(SessionContextManager(validated_config.database_url))
+    context.with_resource(DatabaseResource(validated_config.database_url))
     context.obj["trailblazer_db"] = Store()
 
 

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -32,10 +32,10 @@ class DatabaseResource:
     def __init__(self, db_uri: str):
         self.db_uri = db_uri
 
-    def __enter__(self, _, __, ___):
+    def __enter__(self):
         initialize_database(self.db_uri)
 
-    def __exit__(self):
+    def __exit__(self _, __, ___):
         session: scoped_session = get_session()
         session.remove()
 

--- a/trailblazer/server/app.py
+++ b/trailblazer/server/app.py
@@ -4,7 +4,7 @@ import os
 from flask import Flask
 from flask_cors import CORS
 from flask_reverse_proxy import FlaskReverseProxied
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import scoped_session
 
 from trailblazer.server import api, ext
 from trailblazer.store.database import get_session
@@ -36,20 +36,10 @@ def index():
 
 
 @app.teardown_appcontext
-def teardown_session(exception=None):
+def teardown_session():
     """
     Remove the database session to ensure database resources are released when a
     request has been processed.
     """
-    session: Session = get_session()
-    try:
-        if exception is not None:
-            LOG.error(f"Rolling back due to exception when processing request: {exception}.")
-            session.rollback()
-        else:
-            session.commit()
-    except Exception as e:
-        LOG.error(f"Failed to commit transaction after processing request, rolling back: {e}.")
-        session.rollback()
-    finally:
-        session.remove()
+    session: scoped_session = get_session()
+    session.remove()

--- a/trailblazer/server/app.py
+++ b/trailblazer/server/app.py
@@ -36,7 +36,7 @@ def index():
 
 
 @app.teardown_appcontext
-def teardown_session():
+def teardown_session(_):
     """
     Remove the database session to ensure database resources are released when a
     request has been processed.

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -39,6 +39,7 @@ class CreateHandler(BaseHandler):
         )
         new_analysis.user = self.get_user(email=email) if email else None
         session.add(new_analysis)
+        session.commit()
         return new_analysis
 
     def add_user(self, name: str, email: str) -> User:
@@ -46,4 +47,5 @@ class CreateHandler(BaseHandler):
         session: Session = get_session()
         new_user = User(email=email, name=name)
         session.add(new_user)
+        session.commit()
         return new_user

--- a/trailblazer/store/crud/delete.py
+++ b/trailblazer/store/crud/delete.py
@@ -20,6 +20,7 @@ class DeleteHandler(BaseHandler):
         session: Session = get_session()
         for job in analysis.jobs:
             session.delete(job)
+        session.commit()
 
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:
         """Delete the analysis from the database. Also delete ongoing analysis if 'force' is True.
@@ -37,3 +38,4 @@ class DeleteHandler(BaseHandler):
             )
         LOG.info(f"Deleting analysis: {analysis_id}, for case: {analysis.family}")
         session.delete(analysis)
+        session.commit()

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -267,4 +267,8 @@ class UpdateHandler(BaseHandler):
 
         if status:
             self.update_analysis_status(case_id=analysis.family, status=status)
+
+        session: Session = get_session()
+        session.commit()
+
         return analysis

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
+from sqlalchemy.orm import Session
 
 from trailblazer.apps.slurm.api import (
     cancel_slurm_job,
@@ -15,6 +16,7 @@ from trailblazer.apps.tower.api import TowerAPI, get_tower_api
 from trailblazer.constants import SlurmJobStatus, TrailblazerStatus, WorkflowManager
 from trailblazer.exc import MissingAnalysis, TrailblazerError
 from trailblazer.store.base import BaseHandler
+from trailblazer.store.database import get_session
 from trailblazer.store.models import Analysis, Job, User
 
 LOG = logging.getLogger(__name__)
@@ -26,10 +28,14 @@ class UpdateHandler(BaseHandler):
     def update_analysis_jobs(self, analysis: Analysis, jobs: List[dict]) -> None:
         """Update jobs in the analysis."""
         analysis.jobs = [Job(**job) for job in jobs]
+        session: Session = get_session()
+        session.commit()
 
     def update_user_is_archived(self, user: User, archive: bool = True) -> None:
         """Update is archived for a user in the database."""
         user.is_archived = archive
+        session: Session = get_session()
+        session.commit()
 
     def update_run_status(self, analysis_id: int, analysis_host: Optional[str] = None) -> None:
         """Query entries related to given analysis, and update the Trailblazer database."""
@@ -80,6 +86,8 @@ class UpdateHandler(BaseHandler):
             )
             for job in squeue_result.jobs
         ]
+        session: Session = get_session()
+        session.commit()
 
     def _update_analysis_from_slurm_squeue_output(
         self, analysis: Analysis, analysis_host: Optional[str] = False
@@ -101,6 +109,8 @@ class UpdateHandler(BaseHandler):
         )
         LOG.info(f"Updated status {analysis.family} - {analysis.id}: {analysis.status} ")
         analysis.logged_at = datetime.now()
+        session: Session = get_session()
+        session.commit()
 
     def update_tower_run_status(self, analysis_id: int) -> None:
         """Query tower for entries related to given analysis, and update the Trailblazer database."""
@@ -116,6 +126,8 @@ class UpdateHandler(BaseHandler):
         except Exception as error:
             LOG.error(f"Error logging case - {analysis.family} :  {type(error).__name__}")
             analysis.status = TrailblazerStatus.ERROR
+            session: Session = get_session()
+            session.commit()
 
     def _update_analysis_from_tower_output(
         self, analysis: Analysis, analysis_id: int, tower_api: TowerAPI
@@ -128,6 +140,8 @@ class UpdateHandler(BaseHandler):
         self.update_analysis_jobs(
             analysis=analysis, jobs=tower_api.get_jobs(analysis_id=analysis.id)
         )
+        session: Session = get_session()
+        session.commit()
         LOG.debug(f"Updated status {analysis.family} - {analysis.id}: {analysis.status} ")
 
     def update_analysis_from_slurm_output(
@@ -144,6 +158,8 @@ class UpdateHandler(BaseHandler):
                 f"Error updating analysis for: case - {analysis.family} : {exception.__class__.__name__}"
             )
             analysis.status = TrailblazerStatus.ERROR
+            session: Session = get_session()
+            session.commit()
 
     def update_case_analyses_as_deleted(self, case_id: str) -> Optional[List[Analysis]]:
         """Mark analyses connected to a case as deleted."""
@@ -151,7 +167,8 @@ class UpdateHandler(BaseHandler):
         if analyses:
             for analysis in analyses:
                 analysis.is_deleted = True
-
+            session: Session = get_session()
+            session.commit()
         return analyses
 
     def cancel_ongoing_analysis(
@@ -178,6 +195,8 @@ class UpdateHandler(BaseHandler):
             f"Analysis cancelled manually by user:"
             f" {(self.get_user(email=email).name if self.get_user(email=email) else (email or 'Unknown'))}!"
         )
+        session: Session = get_session()
+        session.commit()
 
     def cancel_slurm_analysis(
         self, analysis: Analysis, analysis_host: Optional[str] = None
@@ -203,6 +222,8 @@ class UpdateHandler(BaseHandler):
             raise ValueError(f"Invalid status. Allowed values are: {TrailblazerStatus.statuses()}")
         analysis: Optional[Analysis] = self.get_latest_analysis_for_case(case_id=case_id)
         analysis.status = status
+        session: Session = get_session()
+        session.commit()
         LOG.info(f"{analysis.family} - Status set to {status.upper()}")
 
     def update_analysis_status_to_completed(self, analysis_id: int) -> None:
@@ -214,10 +235,14 @@ class UpdateHandler(BaseHandler):
         """Set analysis uploaded at for an analysis."""
         analysis: Optional[Analysis] = self.get_latest_analysis_for_case(case_id=case_id)
         analysis.uploaded_at = uploaded_at
+        session: Session = get_session()
+        session.commit()
 
     def update_analysis_comment(self, case_id: str, comment: str) -> None:
         analysis: Optional[Analysis] = self.get_latest_analysis_for_case(case_id=case_id)
         analysis.comment: str = (
             " ".join([analysis.comment, comment]) if analysis.comment else comment
         )
+        session: Session = get_session()
+        session.commit()
         LOG.info(f"Adding comment {comment} to analysis {analysis.family}")


### PR DESCRIPTION
## Description
The transaction management approach taken in https://github.com/Clinical-Genomics/trailblazer/pull/299 is not ideal since the transactions are committed only after responses are sent. This PR restores the original commits in the CRUD handlers.

By committing before we return a response, we ensure that the caller receives an error if something goes wrong against the database.


### Fixed
- Commit transactions before sending response.

### How to test
- [ ] Ensure cigrid views work and data is written
- [ ] Ensure cli works and data is written

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
