### PR TITLE
Speedup retrieving analyses

### DIFF
--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -65,7 +65,6 @@ def analyses():
     for analysis in query_page.all():
         analysis_data = analysis.to_dict()
         analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
-        analysis_data["jobs"] = [job.to_dict() for job in analysis.jobs]
         response_data.append(analysis_data)
     return jsonify(analyses=response_data)
 


### PR DESCRIPTION
## Description
This PR speeds up the `/analyses` endpoint :zap:  It used to be :turtle: and now it is more like :zebra:  Closes https://github.com/Clinical-Genomics/trailblazer/issues/309.

From 25 seconds to 100 ms for retrieving the sars-cov data (rendering is still slow, but that is a frontend issue).
 
The response size was very large (like 70 MB for sars-cov-2), excluding the jobs takes it down to around 200 kB tops. The jobs are not needed in the analysis table in cigrid, so there is no reason to include them in the `/analyses` response. They are fetched again from `/analyses/<id>` when you click on an analysis to get the detailed view.

I have not found any other repo that calls the `/analyses` endpoint.

### Fixed
- Speed up retrieving analyses per pipeline

### How to test
- [x] Deploy to stage vm and check that the views work and load faster

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
