### PR TITLE
fix check is_analysis_failed

### DIFF
--- a/trailblazer/apps/slurm/api.py
+++ b/trailblazer/apps/slurm/api.py
@@ -96,10 +96,10 @@ def _get_analysis_single_status(jobs_status_distribution: dict[str, float]) -> s
 
 def _is_analysis_failed(jobs_status_distribution: dict[str, float]) -> bool:
     """Return true if any job was broken."""
-    broken_statuses: list[str] = [SlurmJobStatus.FAILED, SlurmJobStatus.TIME_OUT]
-    for broken_status in broken_statuses:
-        if jobs_status_distribution.get(broken_status):
-            return True
+    return any(
+        broken_status in jobs_status_distribution
+        for broken_status in [SlurmJobStatus.FAILED, SlurmJobStatus.TIME_OUT]
+    )
 
 
 def _is_analysis_ongoing(jobs_status_distribution: dict[str, float]) -> bool:


### PR DESCRIPTION
## Description

Implements solution 2 in #315. Changes the logic of `_is_analysis_failed` so that it checks if any job failed, instead of checking if the proportion is not zero.


### Changed

- function `_is_analysis_failed` in `trailblazer/apps/slurm/api.py`


### How to prepare for test
- [x] ssh to hasta (depending on type of change)
- [x] activate stage: `us`
- [x] request trailblazer-stage on hasta: `paxa`
- [x] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b 315-fix-analysis-status -a
    ```

### How to test
- [x] In branch `master`, run `trailblazer scan` and make sure that the case `maturejay` is set to cancelled
- [x] In the branch of this PR, run `trailblazer scan` and make sure that the case `maturejay` is set to failed


## Review
- [x] tests executed by SD
- [x] "Merge and deploy" approved by IO, HS
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
