### PR TITLE
Patch update endpoint

### DIFF
--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -6,6 +6,8 @@ from typing import Mapping
 
 from flask import Blueprint, Response, abort, g, jsonify, make_response, request
 from google.auth import jwt
+from http import HTTPStatus
+from pydantic import ValidationError
 from sqlalchemy.orm import Query
 
 from trailblazer.constants import (
@@ -14,6 +16,7 @@ from trailblazer.constants import (
     TrailblazerStatus,
 )
 from trailblazer.server.ext import store
+from trailblazer.server.schemas import AnalysisUpdate
 from trailblazer.store.models import Analysis, Info, User
 from trailblazer.utils.datetime import get_date_number_of_days_ago
 
@@ -77,12 +80,16 @@ def analysis(analysis_id):
         return abort(404)
 
     if request.method == "PUT":
-        status: str | None = request.json.get("status")
-        comment: str | None = request.json.get("comment")
-        is_visible: bool | None = request.json.get("is_visible")
-        store.update_analysis(
-            analysis_id=analysis_id, comment=comment, status=status, is_visible=is_visible
-        )
+        try:
+            analysis_update = AnalysisUpdate.model_validate(request.json)
+            store.update_analysis(
+                analysis_id=analysis_id,
+                comment=analysis_update.comment,
+                status=analysis_update.status,
+                is_visible=analysis_update.is_visible,
+            )
+        except ValidationError as e:
+            return jsonify(error=str(e)), HTTPStatus.BAD_REQUEST
 
     data = analysis.to_dict()
     data["jobs"] = [job.to_dict() for job in analysis.jobs]

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -88,8 +88,8 @@ def analysis(analysis_id):
                 status=analysis_update.status,
                 is_visible=analysis_update.is_visible,
             )
-        except ValidationError as e:
-            return jsonify(error=str(e)), HTTPStatus.BAD_REQUEST
+        except ValidationError as error:
+            return jsonify(error=str(error)), HTTPStatus.BAD_REQUEST
 
     data = analysis.to_dict()
     data["jobs"] = [job.to_dict() for job in analysis.jobs]

--- a/trailblazer/server/schemas.py
+++ b/trailblazer/server/schemas.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class AnalysisUpdate(BaseModel):
+    is_visible: bool | None = None
+    comment: str | None = None
+    status: str | None = None

--- a/trailblazer/server/schemas.py
+++ b/trailblazer/server/schemas.py
@@ -1,7 +1,9 @@
 from pydantic import BaseModel
 
+from trailblazer.constants import TrailblazerStatus
+
 
 class AnalysisUpdate(BaseModel):
     is_visible: bool | None = None
     comment: str | None = None
-    status: str | None = None
+    status: TrailblazerStatus | None = None

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -259,7 +259,7 @@ class UpdateHandler(BaseHandler):
             LOG.info(f"Adding comment {comment} to analysis {analysis.family}")
             analysis.comment = comment
 
-        if is_visible:
+        if is_visible is not None:
             LOG.info(f"Setting visibility to {is_visible} for analysis {analysis.family}")
             analysis.is_visible = bool(is_visible)
 


### PR DESCRIPTION
## Description
The endpoint parsed the `is_visible` field as a string instead of as a bool, causing the hide functionality to break in cigrid-ui. This PR adds a pydantic model for parsing the analysis update request. Closes https://github.com/Clinical-Genomics/cigrid-ui/issues/458.

It would be nice to set up some tests that call the actual endpoints. That way, these bugs would not slip through.

### Fixed
- Toggling of analyses visibility

### How to test
- [ ] deploy to stage
- [ ] ensure analysis stays hidden after refreshing page

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
