### PR TITLE
Add most recent failed job

### DIFF
--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -16,7 +16,7 @@ def test_user_first_name():
     assert first_name == "Paul"
 
 
-def test_most_recent_failed_job():
+def test_analysis_most_recent_failed_job():
     """Test retrieving the most recent failed job."""
     # GIVEN an Analysis with several jobs, including failed ones
     analysis = Analysis(
@@ -29,15 +29,15 @@ def test_most_recent_failed_job():
     )
 
     # WHEN retrieving the most recent failed job
-    most_recent_failed: Job | None = analysis.most_recent_failed_job
+    most_recent_failed: Job | None = analysis.last_failed_job
 
     # THEN it should return the job with the status FAILED and the most recent started_at date
-    assert most_recent_failed is not None
+    assert most_recent_failed
     assert most_recent_failed.status == SlurmJobStatus.FAILED
     assert most_recent_failed.started_at == datetime(2023, 1, 3)
 
 
-def test_retrieving_non_existing_failed_job():
+def test_get_analysis_non_existing_failed_job():
     """Test retrieving the most recent failed job, when none has failed."""
     # GIVEN an Analysis without any failed jobs
     analysis = Analysis(
@@ -45,19 +45,19 @@ def test_retrieving_non_existing_failed_job():
     )
 
     # WHEN retrieving the most recent failed job
-    most_recent_failed: Job | None = analysis.most_recent_failed_job
+    most_recent_failed: Job | None = analysis.last_failed_job
 
     # THEN it should not return any
-    assert most_recent_failed is None
+    assert most_recent_failed
 
 
-def test_most_recent_failed_job_when_no_jobs_exist():
-    """Test retrieving the most recent failed job, when none has failed."""
+def test_get_analysis_most_recent_failed_job_when_no_jobs_exist():
+    """Test retrieving the most recent failed job, when no jobs."""
     # GIVEN an Analysis without any jobs
     analysis = Analysis()
 
     # WHEN retrieving the most recent failed job
-    most_recent_failed: Job | None = analysis.most_recent_failed_job
+    most_recent_failed: Job | None = analysis.last_failed_job
 
     # THEN it should not return any
-    assert most_recent_failed is None
+    assert most_recent_failed

--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -45,10 +45,10 @@ def test_get_analysis_non_existing_failed_job():
     )
 
     # WHEN retrieving the last failed job
-    most_recent_failed: Job | None = analysis.last_failed_job
+    last_failed_job: Job | None = analysis.last_failed_job
 
     # THEN it should not return any
-    assert most_recent_failed
+    assert not last_failed_job
 
 
 def test_get_analysis_last_failed_job_when_no_jobs_exist():
@@ -57,7 +57,7 @@ def test_get_analysis_last_failed_job_when_no_jobs_exist():
     analysis = Analysis()
 
     # WHEN retrieving the last failed job
-    most_recent_failed: Job | None = analysis.last_failed_job
+    last_failed_job: Job | None = analysis.last_failed_job
 
     # THEN it should not return any
-    assert most_recent_failed
+    assert not last_failed_job

--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -1,4 +1,7 @@
-from trailblazer.store.models import User
+from datetime import datetime
+
+from trailblazer.constants import SlurmJobStatus
+from trailblazer.store.models import Analysis, Job, User
 
 
 def test_user_first_name():
@@ -11,3 +14,24 @@ def test_user_first_name():
 
     # THEN it should return the spoken name
     assert first_name == "Paul"
+
+
+def test_most_recent_failed_job():
+    """Test retrieving the most recent failed job."""
+    # GIVEN an Analysis with several jobs, including failed ones
+    analysis = Analysis(
+        jobs=[
+            Job(status=SlurmJobStatus.COMPLETED, started_at=datetime(2023, 1, 1)),
+            Job(status=SlurmJobStatus.FAILED, started_at=datetime(2023, 1, 3)),
+            Job(status=SlurmJobStatus.FAILED, started_at=datetime(2023, 1, 2)),
+            Job(status=SlurmJobStatus.RUNNING, started_at=datetime(2023, 1, 4)),
+        ]
+    )
+
+    # WHEN retrieving the most recent failed job
+    most_recent_failed = analysis.most_recent_failed_job
+
+    # THEN it should return the job with the status FAILED and the most recent started_at date
+    assert most_recent_failed is not None
+    assert most_recent_failed.status == SlurmJobStatus.FAILED
+    assert most_recent_failed.started_at == datetime(2023, 1, 3)

--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -16,8 +16,8 @@ def test_user_first_name():
     assert first_name == "Paul"
 
 
-def test_analysis_most_recent_failed_job():
-    """Test retrieving the most recent failed job."""
+def test_analysis_last_failed_job():
+    """Test retrieving the last failed job."""
     # GIVEN an Analysis with several jobs, including failed ones
     analysis = Analysis(
         jobs=[
@@ -28,35 +28,35 @@ def test_analysis_most_recent_failed_job():
         ]
     )
 
-    # WHEN retrieving the most recent failed job
-    most_recent_failed: Job | None = analysis.last_failed_job
+    # WHEN retrieving the last failed job
+    last_failed: Job | None = analysis.last_failed_job
 
-    # THEN it should return the job with the status FAILED and the most recent started_at date
-    assert most_recent_failed
-    assert most_recent_failed.status == SlurmJobStatus.FAILED
-    assert most_recent_failed.started_at == datetime(2023, 1, 3)
+    # THEN it should return the job with the status FAILED and the last started_at date
+    assert last_failed
+    assert last_failed.status == SlurmJobStatus.FAILED
+    assert last_failed.started_at == datetime(2023, 1, 3)
 
 
 def test_get_analysis_non_existing_failed_job():
-    """Test retrieving the most recent failed job, when none has failed."""
+    """Test retrieving the last failed job, when none has failed."""
     # GIVEN an Analysis without any failed jobs
     analysis = Analysis(
         jobs=[Job(status=SlurmJobStatus.COMPLETED, started_at=datetime(2023, 1, 1))]
     )
 
-    # WHEN retrieving the most recent failed job
+    # WHEN retrieving the last failed job
     most_recent_failed: Job | None = analysis.last_failed_job
 
     # THEN it should not return any
     assert most_recent_failed
 
 
-def test_get_analysis_most_recent_failed_job_when_no_jobs_exist():
-    """Test retrieving the most recent failed job, when no jobs."""
+def test_get_analysis_last_failed_job_when_no_jobs_exist():
+    """Test retrieving the last failed job, when no jobs."""
     # GIVEN an Analysis without any jobs
     analysis = Analysis()
 
-    # WHEN retrieving the most recent failed job
+    # WHEN retrieving the last failed job
     most_recent_failed: Job | None = analysis.last_failed_job
 
     # THEN it should not return any

--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -29,9 +29,35 @@ def test_most_recent_failed_job():
     )
 
     # WHEN retrieving the most recent failed job
-    most_recent_failed = analysis.most_recent_failed_job
+    most_recent_failed: Job | None = analysis.most_recent_failed_job
 
     # THEN it should return the job with the status FAILED and the most recent started_at date
     assert most_recent_failed is not None
     assert most_recent_failed.status == SlurmJobStatus.FAILED
     assert most_recent_failed.started_at == datetime(2023, 1, 3)
+
+
+def test_retrieving_non_existing_failed_job():
+    """Test retrieving the most recent failed job, when none has failed."""
+    # GIVEN an Analysis without any failed jobs
+    analysis = Analysis(
+        jobs=[Job(status=SlurmJobStatus.COMPLETED, started_at=datetime(2023, 1, 1))]
+    )
+
+    # WHEN retrieving the most recent failed job
+    most_recent_failed: Job | None = analysis.most_recent_failed_job
+
+    # THEN it should not return any
+    assert most_recent_failed is None
+
+
+def test_most_recent_failed_job_when_no_jobs_exist():
+    """Test retrieving the most recent failed job, when none has failed."""
+    # GIVEN an Analysis without any jobs
+    analysis = Analysis()
+
+    # WHEN retrieving the most recent failed job
+    most_recent_failed: Job | None = analysis.most_recent_failed_job
+
+    # THEN it should not return any
+    assert most_recent_failed is None

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -68,7 +68,7 @@ def analyses():
     for analysis in query_page.all():
         analysis_data = analysis.to_dict()
         analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
-        failed_job: Job | None = analysis.most_recent_failed_job
+        failed_job: Job | None = analysis.last_failed_job
         analysis_data["failed_job"] = failed_job.to_dict() if failed_job else None
         response_data.append(analysis_data)
     return jsonify(analyses=response_data)

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -17,7 +17,7 @@ from trailblazer.constants import (
 )
 from trailblazer.server.ext import store
 from trailblazer.server.schemas import AnalysisUpdate
-from trailblazer.store.models import Analysis, Info, User
+from trailblazer.store.models import Analysis, Info, Job, User
 from trailblazer.utils.datetime import get_date_number_of_days_ago
 
 ANALYSIS_HOST: str = os.environ.get("ANALYSIS_HOST")
@@ -68,6 +68,8 @@ def analyses():
     for analysis in query_page.all():
         analysis_data = analysis.to_dict()
         analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
+        failed_job: Job | None = analysis.most_recent_failed_job
+        analysis_data["failed_job"] = failed_job.to_dict() if failed_job else None
         response_data.append(analysis_data)
     return jsonify(analyses=response_data)
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -100,7 +100,7 @@ class Analysis(Model):
         return self.status in TrailblazerStatus.ongoing_statuses()
 
     @property
-    def most_recent_failed_job(self):
+    def last_failed_job(self):
         failed_jobs: list[Job] = [job for job in self.jobs if job.status == SlurmJobStatus.FAILED]
         if not failed_jobs:
             return None

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -99,6 +99,14 @@ class Analysis(Model):
         """Check if analysis status is ongoing."""
         return self.status in TrailblazerStatus.ongoing_statuses()
 
+    @property
+    def most_recent_failed_job(self) -> "Job" | None:
+        failed_jobs: list[Job] = [job for job in self.jobs if job.status == SlurmJobStatus.FAILED]
+        if not failed_jobs:
+            return None
+        sorted_jobs: list[Job] = sorted(failed_jobs, key=lambda job: job.started_at, reverse=True)
+        return sorted_jobs[0]
+
     def to_dict(self) -> dict:
         """Return a dictionary representation of the object."""
         return {

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -100,7 +100,7 @@ class Analysis(Model):
         return self.status in TrailblazerStatus.ongoing_statuses()
 
     @property
-    def most_recent_failed_job(self) -> "Job" | None:
+    def most_recent_failed_job(self):
         failed_jobs: list[Job] = [job for job in self.jobs if job.status == SlurmJobStatus.FAILED]
         if not failed_jobs:
             return None


### PR DESCRIPTION
## Description
This PR closes https://github.com/Clinical-Genomics/cigrid-ui/issues/459.
The endpoint returning all analyses now includes the most recent failed job in the response (not all jobs as done before, which caused really big response sizes when retrieving for example the sars-cov data).

The most recent failed job was rendered before as well, so this behaviour is expected.

### Added
- The most recent failed job in the response from the /analyses endpoint

### How to test
- [ ] deploy to stage
- [ ] ensure that the response includes the most recent failed job

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
