### PR TITLE
Ensure the status is updated for the correct analysis

### DIFF
--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -84,7 +84,7 @@ def analysis(analysis_id):
     if request.method == "PUT":
         try:
             analysis_update = AnalysisUpdate.model_validate(request.json)
-            store.update_analysis(
+            analysis = store.update_analysis(
                 analysis_id=analysis_id,
                 comment=analysis_update.comment,
                 status=analysis_update.status,

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -264,7 +264,7 @@ class UpdateHandler(BaseHandler):
             analysis.is_visible = bool(is_visible)
 
         if status:
-            LOG.info(f"Setting status to {status} for analysis {analysis.family}")
+            LOG.info(f"Setting status to {status} for analysis {analysis.id}")
             analysis.status = status
 
         session: Session = get_session()

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -256,15 +256,16 @@ class UpdateHandler(BaseHandler):
         analysis: Analysis = self.get_analysis_with_id(analysis_id)
 
         if comment:
-            LOG.info(f"Adding comment {comment} to analysis {analysis.family}")
+            LOG.info(f"Adding comment {comment} to analysis {analysis.id}")
             analysis.comment = comment
 
         if is_visible is not None:
-            LOG.info(f"Setting visibility to {is_visible} for analysis {analysis.family}")
+            LOG.info(f"Setting visibility to {is_visible} for analysis {analysis.id}")
             analysis.is_visible = bool(is_visible)
 
         if status:
-            self.update_analysis_status(case_id=analysis.family, status=status)
+            LOG.info(f"Setting status to {status} for analysis {analysis.family}")
+            analysis.status = status
 
         session: Session = get_session()
         session.commit()


### PR DESCRIPTION
Closes https://github.com/Clinical-Genomics/cigrid-ui/issues/468. When the analysis status was updated a function called `update_analysis_status` was called. This function does update the status, but it does it for the most recent analysis for a case 🐛 🥲 Patched it so we just set the status directly on the analysis.

I'll set up a separate PR adding some integration tests for our endpoints.

### Fixed
- Updating the status on an analysis

Tested in stage.