### PR TITLE
Improve logging for scan command

### DIFF
--- a/trailblazer/apps/slurm/api.py
+++ b/trailblazer/apps/slurm/api.py
@@ -32,12 +32,10 @@ def cancel_slurm_job(slurm_id: int, analysis_host: str | None = None) -> None:
 
 def get_slurm_squeue_output(slurm_job_id_file: Path, analysis_host: str | None = None) -> str:
     """Return squeue output from ongoing analyses in SLURM."""
-    try:
-        slurm_job_id_file_content: dict[str, list[str]] = ReadFile.get_content_from_file(
-            file_format=FileFormat.YAML, file_path=slurm_job_id_file
-        )
-    except FileNotFoundError as e:
-        raise FileNotFoundError(f"File not found: {slurm_job_id_file}") from e
+    slurm_job_id_file_content: dict[str, list[str]] = ReadFile.get_content_from_file(
+        file_format=FileFormat.YAML, file_path=slurm_job_id_file
+    )
+
     slurm_jobs: str = _get_squeue_jobs_flag_input(
         slurm_job_id_file_content=slurm_job_id_file_content
     )

--- a/trailblazer/apps/slurm/api.py
+++ b/trailblazer/apps/slurm/api.py
@@ -32,9 +32,12 @@ def cancel_slurm_job(slurm_id: int, analysis_host: str | None = None) -> None:
 
 def get_slurm_squeue_output(slurm_job_id_file: Path, analysis_host: str | None = None) -> str:
     """Return squeue output from ongoing analyses in SLURM."""
-    slurm_job_id_file_content: dict[str, list[str]] = ReadFile.get_content_from_file(
-        file_format=FileFormat.YAML, file_path=slurm_job_id_file
-    )
+    try:
+        slurm_job_id_file_content: dict[str, list[str]] = ReadFile.get_content_from_file(
+            file_format=FileFormat.YAML, file_path=slurm_job_id_file
+        )
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"File not found: {slurm_job_id_file}") from e
     slurm_jobs: str = _get_squeue_jobs_flag_input(
         slurm_job_id_file_content=slurm_job_id_file_content
     )

--- a/trailblazer/io/controller.py
+++ b/trailblazer/io/controller.py
@@ -18,7 +18,10 @@ class ReadFile:
     @classmethod
     def get_content_from_file(cls, file_format: str, file_path: Path) -> Any:
         """Read file using file format dispatch table."""
-        return cls.read_file[file_format](file_path=file_path)
+        try:
+            return cls.read_file[file_format](file_path=file_path)
+        except FileNotFoundError as e:
+            raise FileNotFoundError(f"File not found: {file_path}") from e
 
 
 class ReadStream:

--- a/trailblazer/io/controller.py
+++ b/trailblazer/io/controller.py
@@ -20,8 +20,8 @@ class ReadFile:
         """Read file using file format dispatch table."""
         try:
             return cls.read_file[file_format](file_path=file_path)
-        except FileNotFoundError as e:
-            raise FileNotFoundError(f"File not found: {file_path}") from e
+        except FileNotFoundError as error:
+            raise FileNotFoundError(f"File not found: {file_path}") from error
 
 
 class ReadStream:


### PR DESCRIPTION
## Description
Improve logging for failing scan command, see https://github.com/Clinical-Genomics/trailblazer/issues/340.

The scan command sometimes fails with a `FileNotFound` error. This is most likely due to the slurm job file missing for some reason. However, the log message currently does not include the file path so it is hard to tell which file is missing.


### Fixed
- Improve logging for scan command
