### PR TITLE
Remove unnecessary log formatting

### DIFF
--- a/trailblazer/io/controller.py
+++ b/trailblazer/io/controller.py
@@ -18,10 +18,7 @@ class ReadFile:
     @classmethod
     def get_content_from_file(cls, file_format: str, file_path: Path) -> Any:
         """Read file using file format dispatch table."""
-        try:
-            return cls.read_file[file_format](file_path=file_path)
-        except FileNotFoundError as error:
-            raise FileNotFoundError(f"File not found: {file_path}") from error
+        return cls.read_file[file_format](file_path=file_path)
 
 
 class ReadStream:

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -154,9 +154,7 @@ class UpdateHandler(BaseHandler):
                 analysis=analysis, analysis_host=analysis_host
             )
         except Exception as exception:
-            LOG.error(
-                f"Error updating analysis for: case - {analysis.case_id} : {exception.__class__.__name__}"
-            )
+            LOG.error(f"Error updating analysis for: case - {analysis.case_id} : {exception}")
             analysis.status = TrailblazerStatus.ERROR
             session: Session = get_session()
             session.commit()


### PR DESCRIPTION
## Description
I don't like this way of discarding all context for an exception, super annoying. Sure the logs look prettier but they also become useless.

### Fixed
- log formatting

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
