### PR TITLE
Fix error response retrieving certain cases

### DIFF
--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -9,7 +9,7 @@ class FailedJob(BaseModel):
     id: int
     name: str
     slurm_id: int
-    started_at: datetime
+    started_at: datetime | None = None
     status: str
 
 

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -107,7 +107,7 @@ def me():
 @blueprint.route("/aggregate/jobs")
 def aggregate_jobs():
     """Return stats about failed jobs."""
-    number_of_days_ago: int = int(request.args.get("days_back", ONE_MONTH_IN_DAYS))
+    number_of_days_ago = int(request.args.get("days_back", ONE_MONTH_IN_DAYS))
     time_window: datetime = get_date_number_of_days_ago(number_of_days_ago)
     failed_jobs: list[dict[str, str | int]] = store.get_nr_jobs_with_status_per_category(
         status=TrailblazerStatus.FAILED, since_when=time_window
@@ -183,7 +183,7 @@ def delete(analysis_id):
 @blueprint.route("/get-latest-analysis", methods=["POST"])
 def post_get_latest_analysis():
     """Return latest analysis entry for specified case id."""
-    post_request: Response.json = request.json
+    post_request = request.json
     case_id: str = post_request.get("case_id")
     if latest_case_analysis := store.get_latest_analysis_for_case(case_id):
         raw_analysis: dict[str, str] = stringify_timestamps(latest_case_analysis.to_dict())


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/trailblazer/issues/342. Apparently, the `started_at` field for a job can be empty.

### Fixed
- Bug where searching for specific cases causes an error response

### How to test
- [x] deploy to stage
- [x] search for vitalsquid (not present in stage... Well this fix should work)

### This [version](https://semver.org/) is a
- [ ] **PATCH**
