### PR TITLE
Refactor API layer

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,13 +12,12 @@ from trailblazer.constants import (
     PIPELINES,
     PRIORITY_OPTIONS,
     TYPES,
-    Pipeline,
     TrailblazerStatus,
     WorkflowManager,
 )
 from trailblazer.server.app import app
 from trailblazer.store.database import get_session
-from trailblazer.store.models import Analysis
+from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
 
 
@@ -81,6 +80,45 @@ def analyses() -> list[Analysis]:
     session: Session = get_session()
     session.add_all(analyses)
     return analyses
+
+
+@pytest.fixture
+def analysis_with_failed_job() -> Analysis:
+    analysis = Analysis(
+        config_path="config_path",
+        data_analysis="data_analysis",
+        case_id="case_id",
+        out_dir="out_dir",
+        priority=PRIORITY_OPTIONS[0],
+        started_at=datetime.datetime.now(),
+        status=TrailblazerStatus.FAILED,
+        ticket_id="ticket_id",
+        type=TYPES[0],
+        workflow_manager=WorkflowManager.SLURM,
+        is_visible=True,
+    )
+
+    failed_job = Job(
+        analysis_id=analysis.id,
+        name="name",
+        slurm_id=1,
+        status=TrailblazerStatus.FAILED,
+        started_at=datetime.datetime.now(),
+        elapsed=1,
+    )
+    running_job = Job(
+        analysis_id=analysis.id,
+        name="name",
+        slurm_id=1,
+        status=TrailblazerStatus.RUNNING,
+        started_at=datetime.datetime.now(),
+        elapsed=1,
+    )
+    analysis.jobs.append(failed_job)
+    analysis.jobs.append(running_job)
+    session = get_session()
+    session.add_all([analysis, failed_job, running_job])
+    session.commit()
 
 
 @pytest.fixture

--- a/tests/integration/test_aggregate_jobs.py
+++ b/tests/integration/test_aggregate_jobs.py
@@ -1,0 +1,22 @@
+from http import HTTPStatus
+from flask.testing import FlaskClient
+from trailblazer.constants import TrailblazerStatus
+from trailblazer.dto import FailedJobsRequest
+
+from trailblazer.store.models import Analysis
+
+
+def test_get_aggregated_jobs(client: FlaskClient, analysis_with_failed_job: Analysis):
+    # GIVEN a valid request to aggregate failed jobs a month back
+    request = FailedJobsRequest(days_back=31)
+    data: str = request.model_dump_json()
+
+    # WHEN retrieving statistics for the failed jobs
+    response = client.get("/api/v1/aggregate/jobs", data=data, content_type="application/json")
+
+    # THEN it gives a success response
+    assert response.status_code == HTTPStatus.OK
+
+    # THEN it returns the correct number of failed jobs
+    failed_jobs_count: int = sum(job["count"] for job in response.json["jobs"])
+    assert failed_jobs_count == 1

--- a/tests/integration/test_update_analysis.py
+++ b/tests/integration/test_update_analysis.py
@@ -3,7 +3,7 @@ from flask.testing import FlaskClient
 from http import HTTPStatus
 
 from trailblazer.constants import TrailblazerStatus
-from trailblazer.server.schemas import AnalysisUpdateRequest
+from trailblazer.dto import AnalysisUpdateRequest
 from trailblazer.store.models import Analysis
 
 TYPE_JSON = "application/json"

--- a/trailblazer/dto/__init__.py
+++ b/trailblazer/dto/__init__.py
@@ -1,0 +1,6 @@
+from trailblazer.dto.analyses_request import AnalysesRequest
+from trailblazer.dto.analysis_response import AnalysisResponse
+from trailblazer.dto.failed_jobs_request import FailedJobsRequest
+from trailblazer.dto.failed_jobs_response import FailedJobsResponse
+from trailblazer.dto.analysis_update_request import AnalysisUpdateRequest
+from trailblazer.dto.analyses_response import AnalysesResponse

--- a/trailblazer/dto/analyses_request.py
+++ b/trailblazer/dto/analyses_request.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, Field
 from trailblazer.constants import TrailblazerPriority, TrailblazerStatus, TrailblazerTypes
 
 
-class AnalysisRequest(BaseModel):
+class AnalysesRequest(BaseModel):
     pipeline: str | None = ""
     search: str | None = None
     page_size: int | None = Field(alias="pageSize", default=250)

--- a/trailblazer/dto/analyses_response.py
+++ b/trailblazer/dto/analyses_response.py
@@ -4,22 +4,12 @@ from datetime import datetime
 
 class Job(BaseModel):
     analysis_id: int
-    context: str | None = None
     elapsed: int
     id: int
     name: str
     slurm_id: int
     started_at: datetime | None = None
     status: str
-
-
-class User(BaseModel):
-    avatar: str | None = None
-    created_at: datetime
-    email: str
-    id: int
-    is_archived: bool
-    name: str
 
 
 class Analysis(BaseModel):
@@ -41,7 +31,6 @@ class Analysis(BaseModel):
     ticket_id: str | None = None
     type: str | None = None
     uploaded_at: datetime | None = None
-    user: User | None = None
     user_id: int | None = None
     version: str | None = None
     workflow_manager: str

--- a/trailblazer/dto/analyses_response.py
+++ b/trailblazer/dto/analyses_response.py
@@ -47,6 +47,6 @@ class Analysis(BaseModel):
     workflow_manager: str
 
 
-class AnalysisResponse(BaseModel):
+class AnalysesResponse(BaseModel):
     analyses: list[Analysis]
     total_count: int

--- a/trailblazer/dto/analyses_response.py
+++ b/trailblazer/dto/analyses_response.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel
 from datetime import datetime
 
 
-class FailedJob(BaseModel):
+class Job(BaseModel):
     analysis_id: int
     context: str | None = None
     elapsed: int
@@ -28,7 +28,7 @@ class Analysis(BaseModel):
     completed_at: datetime | None = None
     config_path: str | None = None
     data_analysis: str | None = None
-    failed_job: FailedJob | None = None
+    failed_job: Job | None = None
     id: int
     is_deleted: bool = False
     is_visible: bool = True

--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+from trailblazer.constants import TrailblazerStatus, WorkflowManager
+
+
+class User(BaseModel):
+    avatar: str | None = None
+    created_at: datetime | None = None
+    email: str | None = None
+    id: int
+    is_archived: bool | None = False
+    name: str | None = None
+
+
+class Job(BaseModel):
+    analysis_id: int
+    context: str | None = None
+    elapsed: int
+    id: int
+    name: str
+    slurm_id: int
+    started_at: datetime | None = None
+    status: str
+
+
+class AnalysisResponse(BaseModel):
+    id: int
+    case_id: str
+    version: str | None = None
+    logged_at: datetime | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    status: TrailblazerStatus
+    priority: str
+    out_dir: str | None = None
+    config_path: str | None = None
+    comment: str | None = None
+    is_deleted: bool = False
+    is_visible: bool = True
+    type: str | None = None
+    user_id: int | None = None
+    progress: float
+    data_analysis: str | None = None
+    ticket_id: str | None = None
+    uploaded_at: datetime | None
+    workflow_manager: WorkflowManager
+    user: User | None = None
+    latest_failed_job: Job | None = None

--- a/trailblazer/dto/analysis_update_request.py
+++ b/trailblazer/dto/analysis_update_request.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-
 from trailblazer.constants import TrailblazerStatus
 
 

--- a/trailblazer/dto/failed_jobs_request.py
+++ b/trailblazer/dto/failed_jobs_request.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+from trailblazer.constants import ONE_MONTH_IN_DAYS
+
+
+class FailedJobsRequest(BaseModel):
+    days_back: int | None = ONE_MONTH_IN_DAYS

--- a/trailblazer/dto/failed_jobs_response.py
+++ b/trailblazer/dto/failed_jobs_response.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class FailedJobCategoryStatistics(BaseModel):
+    name: str
+    count: int
+
+
+class FailedJobsResponse(BaseModel):
+    jobs: list[FailedJobCategoryStatistics]

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -17,7 +17,7 @@ from trailblazer.dto.analysis_request import AnalysisRequest
 from trailblazer.dto.analysis_response import AnalysisResponse
 from trailblazer.server.ext import store
 from trailblazer.server.schemas import AnalysisUpdateRequest
-from trailblazer.server.utils import parse_analysis_request
+from trailblazer.server.utils import parse_analysis_request, stringify_timestamps
 from trailblazer.services.analysis_service import AnalysisService
 from trailblazer.store.models import Analysis, Info, User
 from trailblazer.utils.datetime import get_date_number_of_days_ago
@@ -25,14 +25,6 @@ from trailblazer.utils.datetime import get_date_number_of_days_ago
 ANALYSIS_HOST: str = os.environ.get("ANALYSIS_HOST")
 
 blueprint = Blueprint("api", __name__, url_prefix="/api/v1")
-
-
-def stringify_timestamps(data: dict) -> dict[str, str]:
-    """Convert datetime into string before dumping in order to avoid information loss"""
-    for key, val in data.items():
-        if isinstance(val, datetime.datetime):
-            data[key] = str(val)
-    return data
 
 
 @blueprint.before_request

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -9,28 +9,21 @@ from google.auth import jwt
 from pydantic import ValidationError
 
 from trailblazer.constants import (
-    ONE_MONTH_IN_DAYS,
     TRAILBLAZER_TIME_STAMP,
-    TrailblazerStatus,
 )
 from trailblazer.dto.analyses_request import AnalysesRequest
 from trailblazer.dto.analyses_response import AnalysesResponse
-from trailblazer.dto.analysis_response import AnalysisResponse
-from trailblazer.dto.failed_jobs_request import FailedJobsRequest
-from trailblazer.dto.failed_jobs_response import FailedJobsResponse
+from trailblazer.dto import AnalysisResponse, AnalysisUpdateRequest, FailedJobsRequest, FailedJobsResponse
 from trailblazer.exc import MissingAnalysis
 from trailblazer.server.ext import store
-from trailblazer.server.schemas import AnalysisUpdateRequest
 from trailblazer.server.utils import (
     parse_analyses_request,
     parse_analysis_update_request,
     parse_get_failed_jobs_request,
     stringify_timestamps,
 )
-from trailblazer.services.analysis_service import AnalysisService
-from trailblazer.services.job_service import JobService
+from trailblazer.services import AnalysisService, JobService
 from trailblazer.store.models import Analysis, Info
-from trailblazer.utils.datetime import get_date_number_of_days_ago
 
 ANALYSIS_HOST: str = os.environ.get("ANALYSIS_HOST")
 

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -59,7 +59,7 @@ def analyses():
         return jsonify(error=str(error)), HTTPStatus.BAD_REQUEST
 
 
-@blueprint.route("/analyses/<int:analysis_id>", methods=["GET"]) 
+@blueprint.route("/analyses/<int:analysis_id>", methods=["GET"])
 def get_analysis(analysis_id):
     analysis_service: AnalysisService = current_app.extensions.get("analysis_service")
     try:

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -13,11 +13,11 @@ from trailblazer.constants import (
     TRAILBLAZER_TIME_STAMP,
     TrailblazerStatus,
 )
-from trailblazer.dto.analysis_request import AnalysisRequest
-from trailblazer.dto.analysis_response import AnalysisResponse
+from trailblazer.dto.analyses_request import AnalysesRequest
+from trailblazer.dto.analyses_response import AnalysesResponse
 from trailblazer.server.ext import store
 from trailblazer.server.schemas import AnalysisUpdateRequest
-from trailblazer.server.utils import parse_analysis_request, stringify_timestamps
+from trailblazer.server.utils import parse_analyses_request, stringify_timestamps
 from trailblazer.services.analysis_service import AnalysisService
 from trailblazer.store.models import Analysis, Info
 from trailblazer.utils.datetime import get_date_number_of_days_ago
@@ -51,8 +51,8 @@ def analyses():
     """Display analyses."""
     analysis_service: AnalysisService = current_app.extensions.get("analysis_service")
     try:
-        query: AnalysisRequest = parse_analysis_request(request)
-        response: AnalysisResponse = analysis_service.get_analyses(query)
+        query: AnalysesRequest = parse_analyses_request(request)
+        response: AnalysesResponse = analysis_service.get_analyses(query)
         return jsonify(response.model_dump()), HTTPStatus.OK
     except ValidationError as error:
         return jsonify(error=str(error)), HTTPStatus.BAD_REQUEST

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -55,8 +55,8 @@ def before_request():
         return abort(403, f"{user_data['email']} doesn't have access")
 
 
-@blueprint.route("/analyses")
-def analyses():
+@blueprint.route("/analyses", methods=["GET"])
+def get_analyses():
     analysis_service: AnalysisService = current_app.extensions.get("analysis_service")
     try:
         query: AnalysesRequest = parse_analyses_request(request)
@@ -104,7 +104,7 @@ def me():
     return jsonify(**g.current_user.to_dict())
 
 
-@blueprint.route("/aggregate/jobs")
+@blueprint.route("/aggregate/jobs", methods=["GET"])
 def get_failed_jobs():
     job_service: JobService = current_app.extensions.get("job_service")
     try:

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -11,9 +11,15 @@ from pydantic import ValidationError
 from trailblazer.constants import (
     TRAILBLAZER_TIME_STAMP,
 )
-from trailblazer.dto.analyses_request import AnalysesRequest
-from trailblazer.dto.analyses_response import AnalysesResponse
-from trailblazer.dto import AnalysisResponse, AnalysisUpdateRequest, FailedJobsRequest, FailedJobsResponse
+
+from trailblazer.dto import (
+    AnalysesRequest,
+    AnalysisResponse,
+    AnalysesResponse,
+    AnalysisUpdateRequest,
+    FailedJobsRequest,
+    FailedJobsResponse,
+)
 from trailblazer.exc import MissingAnalysis
 from trailblazer.server.ext import store
 from trailblazer.server.utils import (

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -130,7 +130,7 @@ def update_analyses():
 
 
 @blueprint.route("/update/<int:analysis_id>", methods=["PUT"])
-def update_analysis(analysis_id):
+def update_analysis_via_process(analysis_id):
     """Update a specific analysis."""
     try:
         process = multiprocessing.Process(

--- a/trailblazer/server/app.py
+++ b/trailblazer/server/app.py
@@ -7,8 +7,7 @@ from flask_reverse_proxy import FlaskReverseProxied
 from sqlalchemy.orm import scoped_session
 
 from trailblazer.server import api, ext
-from trailblazer.services.analysis_service import AnalysisService
-from trailblazer.services.job_service import JobService
+from trailblazer.services import AnalysisService, JobService
 from trailblazer.store.database import get_session
 from trailblazer.store.store import Store
 

--- a/trailblazer/server/app.py
+++ b/trailblazer/server/app.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import scoped_session
 
 from trailblazer.server import api, ext
 from trailblazer.services.analysis_service import AnalysisService
+from trailblazer.services.job_service import JobService
 from trailblazer.store.database import get_session
 from trailblazer.store.store import Store
 
@@ -29,12 +30,15 @@ app.register_blueprint(api.blueprint)
 # services
 store = Store()
 analysis_service = AnalysisService(store)
+job_service = JobService(store)
 
 # configure extensions
 FlaskReverseProxied(app)
 cors = CORS(app, resources={r"/api/*": {"origins": "*"}}, supports_credentials=True)
 ext.store.init_app(app)
+
 app.extensions["analysis_service"] = analysis_service
+app.extensions["job_service"] = job_service
 
 
 @app.route("/")

--- a/trailblazer/server/utils.py
+++ b/trailblazer/server/utils.py
@@ -2,6 +2,7 @@ import datetime
 from flask import Request
 
 from trailblazer.dto.analyses_request import AnalysesRequest
+from trailblazer.dto.failed_jobs_request import FailedJobsRequest
 from trailblazer.server.schemas import AnalysisUpdateRequest
 
 
@@ -18,6 +19,10 @@ def parse_analyses_request(request: Request) -> AnalysesRequest:
 
 def parse_analysis_update_request(request: Request) -> AnalysisUpdateRequest:
     return AnalysisUpdateRequest.model_validate(request.json)
+
+
+def parse_get_failed_jobs_request(request: Request) -> FailedJobsRequest:
+    return FailedJobsRequest.model_validate(request.args)
 
 
 def stringify_timestamps(data: dict) -> dict[str, str]:

--- a/trailblazer/server/utils.py
+++ b/trailblazer/server/utils.py
@@ -1,3 +1,4 @@
+import datetime
 from flask import Request
 
 from trailblazer.dto.analysis_request import AnalysisRequest
@@ -12,3 +13,11 @@ def parse_analysis_request(request: Request) -> AnalysisRequest:
         else:
             query_params[key] = request.args.get(key)
     return AnalysisRequest.model_validate(query_params)
+
+
+def stringify_timestamps(data: dict) -> dict[str, str]:
+    """Convert datetime into string before dumping in order to avoid information loss"""
+    for key, val in data.items():
+        if isinstance(val, datetime.datetime):
+            data[key] = str(val)
+    return data

--- a/trailblazer/server/utils.py
+++ b/trailblazer/server/utils.py
@@ -1,10 +1,10 @@
 import datetime
 from flask import Request
 
-from trailblazer.dto.analysis_request import AnalysisRequest
+from trailblazer.dto.analyses_request import AnalysesRequest
 
 
-def parse_analysis_request(request: Request) -> AnalysisRequest:
+def parse_analyses_request(request: Request) -> AnalysesRequest:
     """Parse a request for retrieving analyses."""
     query_params = {}
     for key in request.args.keys():
@@ -12,7 +12,7 @@ def parse_analysis_request(request: Request) -> AnalysisRequest:
             query_params[key[:-2]] = request.args.getlist(key)
         else:
             query_params[key] = request.args.get(key)
-    return AnalysisRequest.model_validate(query_params)
+    return AnalysesRequest.model_validate(query_params)
 
 
 def stringify_timestamps(data: dict) -> dict[str, str]:

--- a/trailblazer/server/utils.py
+++ b/trailblazer/server/utils.py
@@ -2,6 +2,7 @@ import datetime
 from flask import Request
 
 from trailblazer.dto.analyses_request import AnalysesRequest
+from trailblazer.server.schemas import AnalysisUpdateRequest
 
 
 def parse_analyses_request(request: Request) -> AnalysesRequest:
@@ -13,6 +14,10 @@ def parse_analyses_request(request: Request) -> AnalysesRequest:
         else:
             query_params[key] = request.args.get(key)
     return AnalysesRequest.model_validate(query_params)
+
+
+def parse_analysis_update_request(request: Request) -> AnalysisUpdateRequest:
+    return AnalysisUpdateRequest.model_validate(request.json)
 
 
 def stringify_timestamps(data: dict) -> dict[str, str]:

--- a/trailblazer/server/utils.py
+++ b/trailblazer/server/utils.py
@@ -1,9 +1,7 @@
 import datetime
 from flask import Request
 
-from trailblazer.dto.analyses_request import AnalysesRequest
-from trailblazer.dto.failed_jobs_request import FailedJobsRequest
-from trailblazer.server.schemas import AnalysisUpdateRequest
+from trailblazer.dto import AnalysesRequest, AnalysisUpdateRequest, FailedJobsRequest
 
 
 def parse_analyses_request(request: Request) -> AnalysesRequest:

--- a/trailblazer/server/utils.py
+++ b/trailblazer/server/utils.py
@@ -8,11 +8,15 @@ def parse_analyses_request(request: Request) -> AnalysesRequest:
     """Parse a request for retrieving analyses."""
     query_params = {}
     for key in request.args.keys():
-        if key.endswith("[]"):
+        if key_has_list_of_values(key):
             query_params[key[:-2]] = request.args.getlist(key)
         else:
             query_params[key] = request.args.get(key)
     return AnalysesRequest.model_validate(query_params)
+
+
+def key_has_list_of_values(key: str) -> bool:
+    return key.endswith("[]")
 
 
 def parse_analysis_update_request(request: Request) -> AnalysisUpdateRequest:

--- a/trailblazer/services/__init__.py
+++ b/trailblazer/services/__init__.py
@@ -1,0 +1,2 @@
+from trailblazer.services.job_service import JobService
+from trailblazer.services.analysis_service import AnalysisService

--- a/trailblazer/services/analysis_service.py
+++ b/trailblazer/services/analysis_service.py
@@ -22,7 +22,7 @@ class AnalysisService:
 
     def get_analysis(self, analysis_id: int) -> AnalysisResponse:
         if not (analysis := self.store.get_analysis_with_id(analysis_id)):
-            raise MissingAnalysis(f"Analysis with id {analysis_id} not found")
+            raise MissingAnalysis(f"Analysis with id: {analysis_id} not found")
         return create_analysis_response(analysis)
 
     def update_analysis(self, analysis_id: int, update: AnalysisUpdateRequest) -> AnalysisResponse:

--- a/trailblazer/services/analysis_service.py
+++ b/trailblazer/services/analysis_service.py
@@ -1,5 +1,5 @@
-from trailblazer.dto.analysis_request import AnalysisRequest
-from trailblazer.dto.analysis_response import AnalysisResponse
+from trailblazer.dto.analyses_request import AnalysesRequest
+from trailblazer.dto.analyses_response import AnalysesResponse
 from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
 
@@ -8,16 +8,19 @@ class AnalysisService:
     def __init__(self, store: Store):
         self.store = store
 
-    def get_analyses(self, query: AnalysisRequest) -> AnalysisResponse:
+    def get_analyses(self, query: AnalysesRequest) -> AnalysesResponse:
         analyses, total_analysis_count = self.store.get_filtered_sorted_paginated_analyses(query)
-        response: AnalysisResponse = self._format_response(
+        response: AnalysesResponse = self.create_analyses_response(
             analyses=analyses, total_analysis_count=total_analysis_count
         )
         return response
 
-    def _format_response(
+    def get_analysis(self, analysis_id: int) -> Analysis:
+        return self.store.get_analysis(analysis_id)
+
+    def create_analyses_response(
         self, analyses: list[Analysis], total_analysis_count: int
-    ) -> AnalysisResponse:
+    ) -> AnalysesResponse:
         response_data: list[dict] = []
         for analysis in analyses:
             analysis_data = analysis.to_dict()
@@ -25,4 +28,4 @@ class AnalysisService:
             failed_job: Job = self.store.get_latest_failed_job_for_analysis(analysis.id)
             analysis_data["failed_job"] = failed_job.to_dict() if failed_job else None
             response_data.append(analysis_data)
-        return AnalysisResponse(analyses=response_data, total_count=total_analysis_count)
+        return AnalysesResponse(analyses=response_data, total_count=total_analysis_count)

--- a/trailblazer/services/analysis_service.py
+++ b/trailblazer/services/analysis_service.py
@@ -1,8 +1,10 @@
-from trailblazer.dto.analyses_request import AnalysesRequest
-from trailblazer.dto.analyses_response import AnalysesResponse
-from trailblazer.dto.analysis_response import AnalysisResponse
+from trailblazer.dto import (
+    AnalysesRequest,
+    AnalysisUpdateRequest,
+    AnalysesResponse,
+    AnalysisResponse,
+)
 from trailblazer.exc import MissingAnalysis
-from trailblazer.server.schemas import AnalysisUpdateRequest
 from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
 

--- a/trailblazer/services/analysis_service.py
+++ b/trailblazer/services/analysis_service.py
@@ -5,6 +5,7 @@ from trailblazer.dto import (
     AnalysisResponse,
 )
 from trailblazer.exc import MissingAnalysis
+from trailblazer.services.utils import create_analysis_response
 from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
 
@@ -22,7 +23,7 @@ class AnalysisService:
     def get_analysis(self, analysis_id: int) -> AnalysisResponse:
         if not (analysis := self.store.get_analysis_with_id(analysis_id)):
             raise MissingAnalysis(f"Analysis with id {analysis_id} not found")
-        return self.create_analysis_response(analysis)
+        return create_analysis_response(analysis)
 
     def update_analysis(self, analysis_id: int, update: AnalysisUpdateRequest) -> AnalysisResponse:
         analysis: Analysis = self.store.update_analysis(
@@ -31,13 +32,7 @@ class AnalysisService:
             status=update.status,
             is_visible=update.is_visible,
         )
-        return self.create_analysis_response(analysis)
-
-    def create_analysis_response(self, analysis: Analysis) -> AnalysisResponse:
-        analysis_data: dict = analysis.to_dict()
-        analysis_data["jobs"] = [job.to_dict() for job in analysis.jobs]
-        analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
-        return AnalysisResponse(**analysis_data)
+        return create_analysis_response(analysis)
 
     def create_analyses_response(
         self, analyses: list[Analysis], total_analysis_count: int

--- a/trailblazer/services/analysis_service.py
+++ b/trailblazer/services/analysis_service.py
@@ -2,6 +2,7 @@ from trailblazer.dto.analyses_request import AnalysesRequest
 from trailblazer.dto.analyses_response import AnalysesResponse
 from trailblazer.dto.analysis_response import AnalysisResponse
 from trailblazer.exc import MissingAnalysis
+from trailblazer.server.schemas import AnalysisUpdateRequest
 from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
 
@@ -19,6 +20,15 @@ class AnalysisService:
     def get_analysis(self, analysis_id: int) -> AnalysisResponse:
         if not (analysis := self.store.get_analysis_with_id(analysis_id)):
             raise MissingAnalysis(f"Analysis with id {analysis_id} not found")
+        return self.create_analysis_response(analysis)
+
+    def update_analysis(self, analysis_id: int, update: AnalysisUpdateRequest) -> AnalysisResponse:
+        analysis: Analysis = self.store.update_analysis(
+            analysis_id=analysis_id,
+            comment=update.comment,
+            status=update.status,
+            is_visible=update.is_visible,
+        )
         return self.create_analysis_response(analysis)
 
     def create_analysis_response(self, analysis: Analysis) -> AnalysisResponse:

--- a/trailblazer/services/job_service.py
+++ b/trailblazer/services/job_service.py
@@ -1,10 +1,8 @@
 from datetime import datetime
 from trailblazer.constants import TrailblazerStatus
 
-from trailblazer.dto.failed_jobs_request import FailedJobsRequest
-from trailblazer.dto.failed_jobs_response import FailedJobsResponse
+from trailblazer.dto import FailedJobsRequest, FailedJobsResponse
 from trailblazer.services.utils import create_jobs_response
-from trailblazer.store.models import Job
 from trailblazer.store.store import Store
 from trailblazer.utils.datetime import get_date_number_of_days_ago
 

--- a/trailblazer/services/job_service.py
+++ b/trailblazer/services/job_service.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from trailblazer.constants import TrailblazerStatus
+
+from trailblazer.dto.failed_jobs_request import FailedJobsRequest
+from trailblazer.dto.failed_jobs_response import FailedJobsResponse
+from trailblazer.services.utils import create_jobs_response
+from trailblazer.store.models import Job
+from trailblazer.store.store import Store
+from trailblazer.utils.datetime import get_date_number_of_days_ago
+
+
+class JobService:
+    def __init__(self, store: Store):
+        self.store = store
+
+    def get_failed_jobs(self, request: FailedJobsRequest) -> FailedJobsResponse:
+        time_window: datetime = get_date_number_of_days_ago(request.days_back)
+        failed_jobs: list[dict] = self.store.get_nr_jobs_with_status_per_category(
+            status=TrailblazerStatus.FAILED, since_when=time_window
+        )
+        return create_jobs_response(failed_jobs)

--- a/trailblazer/services/utils.py
+++ b/trailblazer/services/utils.py
@@ -1,0 +1,6 @@
+from trailblazer.dto.failed_jobs_response import FailedJobsResponse
+from trailblazer.store.models import Job
+
+
+def create_jobs_response(failed_job_statistics: list[dict]) -> FailedJobsResponse:
+    return FailedJobsResponse(jobs=failed_job_statistics)

--- a/trailblazer/services/utils.py
+++ b/trailblazer/services/utils.py
@@ -1,6 +1,13 @@
-from trailblazer.dto.failed_jobs_response import FailedJobsResponse
-from trailblazer.store.models import Job
+from trailblazer.dto import AnalysisResponse, FailedJobsResponse
+from trailblazer.store.models import Analysis
 
 
 def create_jobs_response(failed_job_statistics: list[dict]) -> FailedJobsResponse:
     return FailedJobsResponse(jobs=failed_job_statistics)
+
+
+def create_analysis_response(analysis: Analysis) -> AnalysisResponse:
+    analysis_data: dict = analysis.to_dict()
+    analysis_data["jobs"] = [job.to_dict() for job in analysis.jobs]
+    analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
+    return AnalysisResponse(**analysis_data)

--- a/trailblazer/services/utils.py
+++ b/trailblazer/services/utils.py
@@ -10,4 +10,4 @@ def create_analysis_response(analysis: Analysis) -> AnalysisResponse:
     analysis_data: dict = analysis.to_dict()
     analysis_data["jobs"] = [job.to_dict() for job in analysis.jobs]
     analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
-    return AnalysisResponse(**analysis_data)
+    return AnalysisResponse.model_validate(analysis_data)

--- a/trailblazer/store/base.py
+++ b/trailblazer/store/base.py
@@ -4,7 +4,7 @@ from typing import Type
 from sqlalchemy import asc, desc, func
 from sqlalchemy.orm import Query, Session
 from trailblazer.constants import Pipeline
-from trailblazer.dto.analyses_request import AnalysesRequest
+from trailblazer.dto import AnalysesRequest
 
 from trailblazer.store.database import get_session
 from trailblazer.store.filters.analyses_filters import (

--- a/trailblazer/store/base.py
+++ b/trailblazer/store/base.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from typing import Type
 
-from sqlalchemy import asc, desc, func, or_
+from sqlalchemy import asc, desc, func
 from sqlalchemy.orm import Query, Session
 from trailblazer.constants import Pipeline
-from trailblazer.dto.analysis_request import AnalysisRequest
+from trailblazer.dto.analyses_request import AnalysesRequest
 
 from trailblazer.store.database import get_session
 from trailblazer.store.filters.analyses_filters import (
@@ -52,7 +52,7 @@ class BaseHandler:
             analyses = analyses.filter(Analysis.data_analysis == pipeline)
         return analyses
 
-    def get_filtered_analyses(self, analyses: Query, query: AnalysisRequest) -> Query:
+    def get_filtered_analyses(self, analyses: Query, query: AnalysesRequest) -> Query:
         filters: list[AnalysisFilter] = []
         if query.status:
             filters.append(AnalysisFilter.FILTER_BY_STATUSES)
@@ -77,7 +77,7 @@ class BaseHandler:
             analyses=analyses,
         )
 
-    def sort_analyses(self, analyses: Query, query: AnalysisRequest) -> Query:
+    def sort_analyses(self, analyses: Query, query: AnalysesRequest) -> Query:
         if query.sort_field:
             column = getattr(Analysis, query.sort_field)
             if query.sort_order == "asc":
@@ -86,11 +86,11 @@ class BaseHandler:
                 analyses = analyses.order_by(desc(column))
         return analyses
 
-    def paginate_analyses(self, analyses: Query, query: AnalysisRequest) -> Query:
+    def paginate_analyses(self, analyses: Query, query: AnalysesRequest) -> Query:
         return analyses.limit(query.page_size).offset((query.page - 1) * query.page_size)
 
     def get_filtered_sorted_paginated_analyses(
-        self, query: AnalysisRequest
+        self, query: AnalysesRequest
     ) -> tuple[list[Analysis], int]:
         analyses: Query = self.get_analyses_query_by_pipeline(query.pipeline)
         analyses = self.get_filtered_analyses(analyses=analyses, query=query)

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -251,7 +251,10 @@ class UpdateHandler(BaseHandler):
         is_visible: bool | None = None,
     ) -> Analysis:
         """Update an analysis."""
-        analysis: Analysis = self.get_analysis_with_id(analysis_id)
+        analysis: Analysis | None = self.get_analysis_with_id(analysis_id)
+
+        if not analysis:
+            raise MissingAnalysis(f"Analysis {analysis_id} does not exist")
 
         if comment is not None:
             LOG.info(f"Adding comment {comment} to analysis {analysis.id}")


### PR DESCRIPTION
## Description
This PR refactors some of the endpoints in the web api following the pattern

Going down from the api layer to the data access layer
request -> api layer -> pydantic dto model -> service layer -> data access layer -> database model

And then back up again...
database model -> service layer -> pydantic dto model -> api layer -> response

The upside of this pattern is
- Better separation of concerns
- Get rid of logic in api layer
- Avoids passing around dicts
- Better validation of data in requests and responses

### Fixed
- Refactor API layer

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
