### PR TITLE
Remove user from /analyses response

### DIFF
--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -13,15 +13,6 @@ class FailedJob(BaseModel):
     status: str
 
 
-class User(BaseModel):
-    avatar: str | None = None
-    created_at: datetime
-    email: str
-    id: int
-    is_archived: bool
-    name: str
-
-
 class Analysis(BaseModel):
     case_id: str
     comment: str | None = None
@@ -41,7 +32,6 @@ class Analysis(BaseModel):
     ticket_id: str | None = None
     type: str | None = None
     uploaded_at: datetime | None = None
-    user: User | None = None
     user_id: int | None = None
     version: str | None = None
     workflow_manager: str

--- a/trailblazer/services/analysis_service.py
+++ b/trailblazer/services/analysis_service.py
@@ -21,7 +21,6 @@ class AnalysisService:
         response_data: list[dict] = []
         for analysis in analyses:
             analysis_data = analysis.to_dict()
-            analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
             failed_job: Job = self.store.get_latest_failed_job_for_analysis(analysis.id)
             analysis_data["failed_job"] = failed_job.to_dict() if failed_job else None
             response_data.append(analysis_data)


### PR DESCRIPTION
## Description
The user associated with an analysis is no longer displayed in the analysis table in cigrid, so there is no need to return that data in the response. Removing it reduces the response time.

### Fixed
- Remove unnecessary data from response in /analyses endpoint

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
