### PR TITLE
Add action for scanning images

### DIFF
--- a/.github/workflows/scan_image.yaml
+++ b/.github/workflows/scan_image.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "clinicalgenomics/trailblazer-stage:${{ steps.branch-name.outputs.branch_name }}"
+          image-ref: "clinicalgenomics/trailblazer:${{ steps.branch-name.outputs.branch_name }}"
           format: "sarif"
           output: "trivy-results.sarif"
 

--- a/.github/workflows/scan_image.yaml
+++ b/.github/workflows/scan_image.yaml
@@ -1,7 +1,6 @@
-name: Trivy Vulnerability Scanning
+name: Scan image
 
-on:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   trivy-scan:

--- a/.github/workflows/scan_image.yaml
+++ b/.github/workflows/scan_image.yaml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   trivy-scan:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/scan_image.yaml
+++ b/.github/workflows/scan_image.yaml
@@ -1,21 +1,31 @@
-name: build
+name: Trivy Vulnerability Scanning
+
 on:
-  push:
-    branches-ignore:
-      - main
-  pull_request:
+  workflow_run:
+    workflows: ["Build and publish docker image on push"]
+    types:
+      - completed
+
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-20.04
+  trivy-scan:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Extract branch name for Docker tag
+        id: branch-name
+        shell: bash
+        run: |
+          BRANCH_REF="${{ github.event.workflow_run.head_branch }}"
+          BRANCH_NAME=$(echo $BRANCH_REF | sed 's/\//-/g')
+          echo "::set-output name=branch_name::$BRANCH_NAME"
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "clinicalgenomics/trailblazer:${{ github.ref_name }}"
+          image-ref: "clinicalgenomics/trailblazer-stage:${{ steps.branch-name.outputs.branch_name }}"
           format: "sarif"
           output: "trivy-results.sarif"
 

--- a/.github/workflows/scan_image.yaml
+++ b/.github/workflows/scan_image.yaml
@@ -1,0 +1,25 @@
+name: build
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "clinicalgenomics/trailblazer:${{ github.ref_name }}"
+          format: "sarif"
+          output: "trivy-results.sarif"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/scan_image.yaml
+++ b/.github/workflows/scan_image.yaml
@@ -1,10 +1,7 @@
 name: Trivy Vulnerability Scanning
 
 on:
-  workflow_run:
-    workflows: ["Build and publish docker image on push"]
-    types:
-      - completed
+  pull_request:
 
 jobs:
   trivy-scan:


### PR DESCRIPTION
## Description
This PR adds an action which scans the trailblazer image for security issues and displays them in the security tab, for example [here](https://github.com/Clinical-Genomics/trailblazer/security/code-scanning?query=branch%3Ascan-containers+). The action is triggered on all pushes.

The action can also be configured to generate an SBOM if that is something we want as well.

### Added
- Action for scanning images for vulnerabilities

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
