### PR TITLE
Remove unused endpoints

### DIFF
--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -135,20 +135,6 @@ def get_failed_jobs():
         return jsonify(error=str(error)), HTTPStatus.BAD_REQUEST
 
 
-@blueprint.route("/update/<int:analysis_id>", methods=["PUT"])
-def update_analysis_via_process(analysis_id):
-    """Update a specific analysis."""
-    try:
-        process = multiprocessing.Process(
-            target=store.update_run_status,
-            kwargs={"analysis_id": analysis_id, "analysis_host": ANALYSIS_HOST},
-        )
-        process.start()
-        return jsonify("Success! Update request sent"), HTTPStatus.CREATED
-    except Exception as error:
-        return jsonify(f"Exception: {error}"), HTTPStatus.CONFLICT
-
-
 # CG REST INTERFACE ###
 # ONLY POST routes which accept messages in specific format
 # NOT for use with GUI (for now)

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -149,20 +149,6 @@ def update_analysis_via_process(analysis_id):
         return jsonify(f"Exception: {error}"), HTTPStatus.CONFLICT
 
 
-@blueprint.route("/delete/<int:analysis_id>", methods=["PUT"])
-def delete(analysis_id):
-    """Delete an analysis and all slurm jobs associated with it."""
-    try:
-        process = multiprocessing.Process(
-            target=store.delete_analysis,
-            kwargs={"analysis_id": analysis_id, "force": True},
-        )
-        process.start()
-        return jsonify("Success! Delete request sent!"), HTTPStatus.CREATED
-    except Exception as error:
-        return jsonify(f"Exception: {error}"), HTTPStatus.CONFLICT
-
-
 # CG REST INTERFACE ###
 # ONLY POST routes which accept messages in specific format
 # NOT for use with GUI (for now)

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 from http import HTTPStatus
 from typing import Mapping


### PR DESCRIPTION
## Description
From what I can see, the `/update` and `/delete` endpoints are not used anywhere and can be removed. Please double check.

Neither of the endpoints show up in the logs on cg-prod-services. So I'm quite certain these can be removed.

### Fixed
- Remove endpoints which are not called

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
