### PR TITLE
Include upload jobs in analysis response

### DIFF
--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -47,3 +47,4 @@ class AnalysisResponse(BaseModel):
     user: User | None = None
     latest_failed_job: Job | None = None
     jobs: list[Job] = []
+    upload_jobs: list[Job] = []

--- a/trailblazer/services/utils.py
+++ b/trailblazer/services/utils.py
@@ -10,6 +10,7 @@ def create_jobs_response(failed_job_statistics: list[dict]) -> FailedJobsRespons
 def create_analysis_response(analysis: Analysis) -> AnalysisResponse:
     analysis_data: dict = analysis.to_dict()
     analysis_data["jobs"] = [job.to_dict() for job in analysis.jobs]
+    analysis_data["upload_jobs"] = [job.to_dict() for job in analysis.upload_jobs]
     analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
     return AnalysisResponse.model_validate(analysis_data)
 

--- a/trailblazer/services/utils.py
+++ b/trailblazer/services/utils.py
@@ -9,7 +9,7 @@ def create_jobs_response(failed_job_statistics: list[dict]) -> FailedJobsRespons
 
 def create_analysis_response(analysis: Analysis) -> AnalysisResponse:
     analysis_data: dict = analysis.to_dict()
-    analysis_data["jobs"] = [job.to_dict() for job in analysis.jobs]
+    analysis_data["jobs"] = [job.to_dict() for job in analysis.analysis_jobs]
     analysis_data["upload_jobs"] = [job.to_dict() for job in analysis.upload_jobs]
     analysis_data["user"] = analysis.user.to_dict() if analysis.user else None
     return AnalysisResponse.model_validate(analysis_data)

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -98,7 +98,7 @@ class Analysis(Model):
         return self.status in TrailblazerStatus.ongoing_statuses()
 
     @property
-    def upload_jobs(self) -> list:
+    def upload_jobs(self) -> list["Job"]:
         """Return upload jobs."""
         return [job for job in self.jobs if job.job_type == JobType.UPLOAD]
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -100,7 +100,7 @@ class Analysis(Model):
     @property
     def upload_jobs(self) -> list:
         """Return upload jobs."""
-        return [job for job in self.jobs if job.job_type == "upload"]
+        return [job for job in self.jobs if job.job_type == JobType.UPLOAD]
 
     def to_dict(self) -> dict:
         """Return a dictionary representation of the object."""

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -97,6 +97,11 @@ class Analysis(Model):
         """Check if analysis status is ongoing."""
         return self.status in TrailblazerStatus.ongoing_statuses()
 
+    @property
+    def upload_jobs(self) -> list:
+        """Return upload jobs."""
+        return [job for job in self.jobs if job.job_type == "upload"]
+
     def to_dict(self) -> dict:
         """Return a dictionary representation of the object."""
         return {

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -98,6 +98,11 @@ class Analysis(Model):
         return self.status in TrailblazerStatus.ongoing_statuses()
 
     @property
+    def analysis_jobs(self) -> list["Job"]:
+        """Return upload jobs."""
+        return [job for job in self.jobs if job.job_type == JobType.ANALYSIS]
+
+    @property
     def upload_jobs(self) -> list["Job"]:
         """Return upload jobs."""
         return [job for job in self.jobs if job.job_type == JobType.UPLOAD]


### PR DESCRIPTION
## Description
This PR ensures any upload jobs for an analysis is included in the response from the `/analysis` endpoint. Part of the [implementation plan](https://github.com/Clinical-Genomics/cigrid-ui/issues/492#issuecomment-1905771598) for https://github.com/Clinical-Genomics/cigrid-ui/issues/492.

### Fixed
- Add upload jobs to analysis response

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
