### PR TITLE
Ensure upload jobs are not overwritten

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from trailblazer.constants import (
     TOWER_TIMESTAMP_FORMAT,
     FileExtension,
     FileFormat,
+    JobType,
     TrailblazerStatus,
 )
 from trailblazer.io.controller import ReadFile
@@ -27,7 +28,7 @@ from trailblazer.store.database import (
     get_session,
     initialize_database,
 )
-from trailblazer.store.models import Analysis
+from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
 
 
@@ -344,3 +345,20 @@ def tower_case_config() -> dict[str, dict]:
             "analysis_id": 1,
         },
     }
+
+
+@pytest.fixture
+def analysis_with_upload_jobs(case_id: str) -> Analysis:
+    upload_job = Job(
+        name="upload",
+        slurm_id="123456",
+        job_type=JobType.UPLOAD,
+        status=TrailblazerStatus.COMPLETED,
+        started_at=datetime.now(),
+        elapsed=10,
+    )
+    analysis = Analysis(case_id=case_id)
+    analysis.jobs.append(upload_job)
+    session = get_session()
+    session.add(analysis)
+    return analysis

--- a/tests/store/crud/test_delete.py
+++ b/tests/store/crud/test_delete.py
@@ -81,3 +81,15 @@ def test_delete_analysis_with_ongoing_analysis_no_force(analysis_store: MockStor
         analysis_store.delete_analysis(analysis_id=analysis.id)
 
     # THEN error should be raised
+
+
+def test_upload_jobs_remain_when_analysis_jobs_are_deleted(
+    analysis_store: MockStore, analysis_with_upload_jobs: Analysis
+):
+    # GIVEN an analysis with upload jobs
+
+    # WHEN deleting its analysis jobs
+    analysis_store.delete_analysis_jobs(analysis_with_upload_jobs)
+
+    # THEN the upload job remains
+    assert analysis_with_upload_jobs.jobs

--- a/tests/store/crud/test_delete.py
+++ b/tests/store/crud/test_delete.py
@@ -14,7 +14,7 @@ def test_delete_analysis_jobs(analysis_store: MockStore, tower_jobs: list[dict],
     assert not analysis.jobs
 
     # WHEN jobs are updated
-    analysis_store.update_analysis_jobs(analysis=analysis, jobs=tower_jobs[:2])
+    analysis_store.update_jobs(jobs=tower_jobs[:2])
 
     assert analysis.jobs
 

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -26,7 +26,7 @@ def test_update_analysis_jobs(analysis_store: MockStore, tower_jobs: list[dict],
     assert not analysis.jobs
 
     # WHEN jobs are updated
-    analysis_store.update_analysis_jobs(analysis=analysis, jobs=tower_jobs[:2])
+    analysis_store.update_jobs(jobs=tower_jobs[:2])
 
     # THEN there should be jobs
     assert analysis.jobs
@@ -191,8 +191,11 @@ def test_cancel_ongoing_slurm_analysis(
         case_id=ongoing_analysis_case_id
     )
 
+    for job in tower_jobs:
+        job["analysis_id"] = analysis.id
+
     # Analysis should have jobs that can be cancelled
-    analysis_store.update_analysis_jobs(analysis=analysis, jobs=tower_jobs[:2])
+    analysis_store.update_jobs(jobs=tower_jobs[:2])
     assert analysis.jobs
 
     # WHEN running cancel ongoing analysis
@@ -396,7 +399,7 @@ def test_update_tower_jobs(analysis_store: MockStore, tower_jobs: list[dict], ca
     assert not analysis.jobs
 
     # WHEN jobs are updated
-    analysis_store.update_analysis_jobs(analysis=analysis, jobs=tower_jobs[:2])
+    analysis_store.update_jobs(jobs=tower_jobs[:2])
 
     # THEN jobs should be updated
     assert len(analysis.jobs) == 2

--- a/trailblazer/store/crud/delete.py
+++ b/trailblazer/store/crud/delete.py
@@ -2,7 +2,7 @@ import logging
 
 from sqlalchemy.orm import Session
 
-from trailblazer.constants import TrailblazerStatus
+from trailblazer.constants import JobType, TrailblazerStatus
 from trailblazer.exc import MissingAnalysis, TrailblazerError
 from trailblazer.store.base import BaseHandler
 from trailblazer.store.database import get_session
@@ -18,7 +18,8 @@ class DeleteHandler(BaseHandler):
         """Delete all jobs linked to the given analysis."""
         session: Session = get_session()
         for job in analysis.jobs:
-            session.delete(job)
+            if job.job_type == JobType.ANALYSIS:
+                session.delete(job)
         session.commit()
 
     def delete_analysis(self, analysis_id: int, force: bool = False) -> None:

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 class UpdateHandler(BaseHandler):
     """Class for updating items in the database."""
 
-    def update_analysis_jobs(self, jobs: list[dict]) -> None:
+    def update_jobs(self, jobs: list[dict]) -> None:
         """Update jobs in the analysis."""
         session: Session = get_session()
         for job in jobs:
@@ -138,7 +138,7 @@ class UpdateHandler(BaseHandler):
         analysis.logged_at = datetime.now()
         self.delete_analysis_jobs(analysis)
         jobs: list[dict] = tower_api.get_jobs(analysis.id)
-        self.update_analysis_jobs(jobs)
+        self.update_jobs(jobs)
         session: Session = get_session()
         session.commit()
         LOG.debug(f"Updated status {analysis.case_id} - {analysis.id}: {analysis.status} ")


### PR DESCRIPTION
## Description
The current logic for updating analysis jobs overwrites all existing ones. Since we have added a separate category of jobs (upload jobs) which are associated with an analysis, this is not desirable.

Instead, only the *analysis* jobs are deleted by the `delete_analysis_jobs`.

### Fixed
- Ensure upload jobs are not deleted

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
