### PR TITLE
Refactor endpoint for creating analysis

### DIFF
--- a/tests/integration/endpoints/test_add_pending_analysis.py
+++ b/tests/integration/endpoints/test_add_pending_analysis.py
@@ -1,0 +1,31 @@
+from flask.testing import FlaskClient
+from http import HTTPStatus
+from trailblazer.constants import TrailblazerPriority, TrailblazerTypes
+
+from trailblazer.dto.create_analysis_request import CreateAnalysisRequest
+from trailblazer.store.store import Store
+
+TYPE_JSON = "application/json"
+
+
+def test_adding_analysis(client: FlaskClient, store: Store):
+    # GIVEN a valid request to add an analysis
+    create_analysis_request = CreateAnalysisRequest(
+        case_id="case_id",
+        config_path="config_path",
+        data_analysis=TrailblazerTypes.WGS,
+        priority=TrailblazerPriority.NORMAL,
+        out_dir="out_dir",
+        ticket_id="ticket_id",
+    )
+    data: str = create_analysis_request.model_dump_json()
+
+    # WHEN sending the request
+    response = client.post("/api/v1/add-pending-analysis", data=data, content_type=TYPE_JSON)
+
+    # THEN it gives a success response
+    assert response.status_code == HTTPStatus.CREATED
+
+    # THEN the analysis was persisted
+    analysis_id = int(response.json["id"])
+    assert store.get_analysis_with_id(analysis_id)

--- a/tests/store/crud/test_create.py
+++ b/tests/store/crud/test_create.py
@@ -1,34 +1,6 @@
 from tests.mocks.store_mock import MockStore
 from trailblazer.store.filters.user_filters import UserFilter, apply_user_filter
-from trailblazer.store.models import Analysis, User
-
-
-def test_add_pending_analysis(raw_analyses: list[dict], store: MockStore, user_email: str):
-    """Test adding a new analysis to the database."""
-    # GIVEN an empty database
-    assert not store.get_query(table=Analysis).first()
-
-    # GIVEN an unprocessed raw analysis
-    analysis: dict = raw_analyses[0]
-
-    # WHEN adding a new analysis
-    new_analysis: Analysis = store.add_pending_analysis(
-        case_id=analysis.get("case_id"),
-        config_path=analysis.get("config_path"),
-        email=user_email,
-        out_dir=analysis.get("out_dir"),
-        priority=analysis.get("priority"),
-        type=analysis.get("type"),
-    )
-
-    # THEN it should be stored in the database
-    stored_analysis: Analysis = store.get_analysis(
-        case_id=analysis.get("case_id"),
-        started_at=new_analysis.started_at,
-        status=analysis.get("status"),
-    )
-    assert new_analysis and stored_analysis
-    assert stored_analysis == new_analysis
+from trailblazer.store.models import User
 
 
 def test_add_user(store: MockStore, user_email: str, username: str):

--- a/trailblazer/dto/__init__.py
+++ b/trailblazer/dto/__init__.py
@@ -6,3 +6,4 @@ from trailblazer.dto.failed_jobs_request import FailedJobsRequest  # noqa: F401
 from trailblazer.dto.failed_jobs_response import FailedJobsResponse  # noqa: F401
 from trailblazer.dto.create_job_request import CreateJobRequest  # noqa: F401
 from trailblazer.dto.job_response import JobResponse  # noqa: F401
+from trailblazer.dto.create_analysis_request import CreateAnalysisRequest  # noqa: F401

--- a/trailblazer/dto/create_analysis_request.py
+++ b/trailblazer/dto/create_analysis_request.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+from trailblazer.constants import JobType, TrailblazerPriority, TrailblazerTypes, WorkflowManager
+
+
+class CreateAnalysisRequest(BaseModel):
+    case_id: str
+    email: str | None = None
+    type: JobType | None = JobType.ANALYSIS
+    config_path: str
+    out_dir: str
+    priority: TrailblazerPriority
+    data_analysis: TrailblazerTypes
+    ticket_id: str | None = None
+    workflow_manager: WorkflowManager | None = None

--- a/trailblazer/dto/create_analysis_request.py
+++ b/trailblazer/dto/create_analysis_request.py
@@ -6,7 +6,6 @@ from trailblazer.constants import JobType, TrailblazerPriority, TrailblazerTypes
 class CreateAnalysisRequest(BaseModel):
     case_id: str
     email: str | None = None
-    type: JobType | None = JobType.ANALYSIS
     config_path: str
     out_dir: str
     priority: TrailblazerPriority

--- a/trailblazer/dto/create_analysis_request.py
+++ b/trailblazer/dto/create_analysis_request.py
@@ -9,6 +9,6 @@ class CreateAnalysisRequest(BaseModel):
     config_path: str
     out_dir: str
     priority: TrailblazerPriority
-    data_analysis: TrailblazerTypes
+    data_analysis: TrailblazerTypes | None = None
     ticket_id: str | None = None
     workflow_manager: WorkflowManager | None = None

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -38,7 +38,7 @@ from trailblazer.server.utils import (
 )
 from trailblazer.services.analysis_service import AnalysisService
 from trailblazer.services.job_service import JobService
-from trailblazer.store.models import Analysis, Info
+from trailblazer.store.models import Info
 
 blueprint = Blueprint("api", __name__, url_prefix="/api/v1")
 
@@ -166,8 +166,6 @@ def post_add_pending_analysis(
         return jsonify(response.model_dump()), HTTPStatus.CREATED
     except ValidationError as error:
         return jsonify(error=str(error)), HTTPStatus.BAD_REQUEST
-    except Exception as error:
-        return jsonify(error=str(error)), HTTPStatus.CONFLICT
 
 
 @blueprint.route("/set-analysis-uploaded", methods=["PUT"])

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -66,8 +66,8 @@ def before_request():
 @inject
 def get_analyses(analysis_service: AnalysisService = Provide[Container.analysis_service]):
     try:
-        query: AnalysesRequest = parse_analyses_request(request)
-        response: AnalysesResponse = analysis_service.get_analyses(query)
+        request_data: AnalysesRequest = parse_analyses_request(request)
+        response: AnalysesResponse = analysis_service.get_analyses(request_data)
         return jsonify(response.model_dump()), HTTPStatus.OK
     except ValidationError as error:
         return jsonify(error=str(error)), HTTPStatus.BAD_REQUEST
@@ -104,9 +104,9 @@ def update_analysis(
     analysis_id: int, analysis_service: AnalysisService = Provide[Container.analysis_service]
 ):
     try:
-        update: AnalysisUpdateRequest = parse_analysis_update_request(request)
+        request_data: AnalysisUpdateRequest = parse_analysis_update_request(request)
         response: AnalysisResponse = analysis_service.update_analysis(
-            analysis_id=analysis_id, update=update
+            analysis_id=analysis_id, update=request_data
         )
         return jsonify(response.model_dump()), HTTPStatus.OK
     except MissingAnalysis as error:

--- a/trailblazer/services/analysis_service.py
+++ b/trailblazer/services/analysis_service.py
@@ -3,6 +3,7 @@ from trailblazer.dto import (
     AnalysesResponse,
     AnalysisResponse,
     AnalysisUpdateRequest,
+    CreateAnalysisRequest,
 )
 from trailblazer.exc import MissingAnalysis
 from trailblazer.services.utils import create_analysis_response
@@ -32,6 +33,10 @@ class AnalysisService:
             status=update.status,
             is_visible=update.is_visible,
         )
+        return create_analysis_response(analysis)
+
+    def add_pending_analysis(self, request_data: CreateAnalysisRequest) -> AnalysisResponse:
+        analysis: Analysis = self.store.add_pending_analysis(request_data)
         return create_analysis_response(analysis)
 
     def create_analyses_response(

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -25,7 +25,6 @@ class CreateHandler(BaseHandler):
             started_at=datetime.now(),
             status=TrailblazerStatus.PENDING,
             ticket_id=analysis_data.ticket_id,
-            type=analysis_data.type,
             workflow_manager=analysis_data.workflow_manager,
         )
 

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -2,7 +2,8 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 
-from trailblazer.constants import JobType, SlurmJobStatus, TrailblazerStatus
+from trailblazer.constants import SlurmJobStatus, TrailblazerStatus
+from trailblazer.dto.create_analysis_request import CreateAnalysisRequest
 from trailblazer.dto.create_job_request import CreateJobRequest
 from trailblazer.store.base import BaseHandler
 from trailblazer.store.database import get_session
@@ -12,33 +13,26 @@ from trailblazer.store.models import Analysis, Job, User
 class CreateHandler(BaseHandler):
     """Class for creating items in the database."""
 
-    def add_pending_analysis(
-        self,
-        case_id: str,
-        config_path: str,
-        out_dir: str,
-        priority: str,
-        type: str,
-        email: str = None,
-        data_analysis: str = None,
-        ticket_id: str = None,
-        workflow_manager: str = None,
-    ) -> Analysis:
-        """Add pending analysis with user if supplied with email."""
+    def add_pending_analysis(self, analysis_data: CreateAnalysisRequest) -> Analysis:
         session: Session = get_session()
+
         new_analysis = Analysis(
-            config_path=config_path,
-            data_analysis=data_analysis,
-            case_id=case_id,
-            out_dir=out_dir,
-            priority=priority,
+            config_path=analysis_data.config_path,
+            data_analysis=analysis_data.data_analysis,
+            case_id=analysis_data.case_id,
+            out_dir=analysis_data.out_dir,
+            priority=analysis_data.priority,
             started_at=datetime.now(),
             status=TrailblazerStatus.PENDING,
-            ticket_id=ticket_id,
-            type=type,
-            workflow_manager=workflow_manager,
+            ticket_id=analysis_data.ticket_id,
+            type=analysis_data.type,
+            workflow_manager=analysis_data.workflow_manager,
         )
-        new_analysis.user = self.get_user(email=email) if email else None
+
+        if analysis_data.email:
+            user: User = self.get_user(analysis_data.email)
+            new_analysis.user = user
+
         session.add(new_analysis)
         session.commit()
         return new_analysis


### PR DESCRIPTION
## Description
Refactor `add-pending-analysis` endpoint to follow the pattern of
request -> pydantic model -> service layer -> database layer -> database model -> service layer -> pydantic model -> response.

### Fixed
- Refactor endpoint for creating analyses
- Add new integration test

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
