### PR TITLE
Add order column to analysis

### DIFF
--- a/alembic/versions/2024_02_02_4b925b29ac45_add_order_to_analysis.py
+++ b/alembic/versions/2024_02_02_4b925b29ac45_add_order_to_analysis.py
@@ -1,0 +1,24 @@
+"""Add order to analysis
+
+Revision ID: 4b925b29ac45
+Revises: 2455fd7f51c4
+Create Date: 2024-02-02 13:22:01.439426
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4b925b29ac45'
+down_revision = '2455fd7f51c4'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(table_name="analysis", column=sa.Column(name="order_id", type_=sa.Integer, index=True))
+
+
+def downgrade():
+    op.drop_column(table_name="analysis", column_name="order_id")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -98,6 +98,7 @@ def analyses() -> list[Analysis]:
                         type=type,
                         workflow_manager=WorkflowManager.SLURM,
                         is_visible=True,
+                        order_id=len(analyses)
                     )
                     analyses.append(analysis)
                 analysis.comment = "comment"  # Ensure some analyses have a comment

--- a/tests/integration/endpoints/test_get_analyses.py
+++ b/tests/integration/endpoints/test_get_analyses.py
@@ -118,3 +118,15 @@ def test_get_analyses_by_pipeline(client: FlaskClient, analyses: list[Analysis])
 
     # THEN it should only return mip analyses
     assert all(a["data_analysis"] == Pipeline.MIP_DNA.lower() for a in response.json["analyses"])
+
+def test_get_analyses_by_order_id(client: FlaskClient, analyses: list[Analysis]):
+    # GIVEN analyses with different pipelines
+
+    # WHEN retrieving all analyses with order_id=0
+    response = client.get("/api/v1/analyses?orderId=0")
+
+    # THEN it gives a success response
+    assert response.status_code == HTTPStatus.OK
+
+    # THEN it should only return the analyses with order_id=0
+    assert all(analysis["order_id"] == 0 for analysis in response.json["analyses"])

--- a/trailblazer/dto/analyses_request.py
+++ b/trailblazer/dto/analyses_request.py
@@ -18,3 +18,4 @@ class AnalysesRequest(BaseModel):
     priority: list[TrailblazerPriority] | None = []
     type: list[TrailblazerTypes] | None = []
     comment: list[str] | None = []
+    order_id: int | None = Field(alias="orderId", default=None)

--- a/trailblazer/store/base.py
+++ b/trailblazer/store/base.py
@@ -54,20 +54,24 @@ class BaseHandler:
 
     def get_filtered_analyses(self, analyses: Query, query: AnalysesRequest) -> Query:
         filters: list[AnalysisFilter] = []
-        if query.status:
-            filters.append(AnalysisFilter.FILTER_BY_STATUSES)
-        if query.priority:
-            filters.append(AnalysisFilter.FILTER_BY_PRIORITIES)
-        if query.type:
-            filters.append(AnalysisFilter.FILTER_BY_TYPES)
         if query.comment:
             filters.append(AnalysisFilter.FILTER_BY_EMPTY_COMMENT)
+        if query.order_id:
+            filters.append(AnalysisFilter.FILTER_BY_ORDER_ID)
+        if query.priority:
+            filters.append(AnalysisFilter.FILTER_BY_PRIORITIES)
+        if query.status:
+            filters.append(AnalysisFilter.FILTER_BY_STATUSES)
+        if query.type:
+            filters.append(AnalysisFilter.FILTER_BY_TYPES)
+
         return apply_analysis_filter(
             filter_functions=filters,
             analyses=analyses,
             comment=query.comment,
-            statuses=query.status,
+            order_id=query.order_id,
             priorities=query.priority,
+            statuses=query.status,
             types=query.type,
         )
 

--- a/trailblazer/store/filters/analyses_filters.py
+++ b/trailblazer/store/filters/analyses_filters.py
@@ -29,6 +29,11 @@ def filter_analyses_by_is_visible(analyses: Query, **kwargs) -> Query:
     return analyses.filter(Analysis.is_visible.is_(True))
 
 
+def filter_analyses_by_order_id(analyses: Query, order_id: int, **kwargs) -> Query:
+    """Filter analyses by case when is visible is true."""
+    return analyses.filter(Analysis.order_id == order_id)
+
+
 def filter_analyses_by_search_term(analyses: Query, search_term: str, **kwargs) -> Query:
     """Filter analyses by search term using multiple fields."""
     return analyses.filter(
@@ -85,6 +90,7 @@ class AnalysisFilter(Enum):
     FILTER_BY_ENTRY_ID: Callable = filter_analyses_by_entry_id
     FILTER_BY_SEARCH_TERM: Callable = filter_analyses_by_search_term
     FILTER_BY_IS_VISIBLE: Callable = filter_analyses_by_is_visible
+    FILTER_BY_ORDER_ID: Callable = filter_analyses_by_order_id
     FILTER_BY_PRIORITIES: Callable = filter_analyses_by_priorites
     FILTER_BY_STARTED_AT: Callable = filter_analyses_by_started_at
     FILTER_BY_STATUS: Callable = filter_analyses_by_status
@@ -97,12 +103,13 @@ def apply_analysis_filter(
     filter_functions: list[Callable],
     analysis_id: int | None = None,
     case_id: str | None = None,
-    search_term: str | None = None,
     comment: str | None = None,
+    order_id: int | None = None,
+    priorities: list[str] | None = None,
+    search_term: str | None = None,
     started_at: datetime | None = None,
     status: str | None = None,
     statuses: list[str] | None = None,
-    priorities: list[str] | None = None,
     types: list[str] | None = None,
 ) -> Query:
     """Apply filtering functions and return filtered results."""
@@ -114,11 +121,12 @@ def apply_analysis_filter(
             analysis_id=analysis_id,
             case_id=case_id,
             comment=comment,
+            order_id=order_id,
+            priorities=priorities,
             search_term=search_term,
             started_at=started_at,
             status=status,
             statuses=statuses,
-            priorities=priorities,
             types=types,
         )
     return analyses

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -89,6 +89,7 @@ class Analysis(Model):
     ticket_id = Column(types.String(32))
     uploaded_at = Column(types.DateTime)
     workflow_manager = Column(types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM)
+    order_id = Column(types.Integer, index=True)
 
     jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
 


### PR DESCRIPTION
## Description

This PR adds a column to the Analysis table and makes the results from the endpoint filterable on the field.

### Added

- order_id to Analysis

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
