### PR TITLE
Add filter parameters to analyses endpoint

### DIFF
--- a/trailblazer/dto/analyses_request.py
+++ b/trailblazer/dto/analyses_request.py
@@ -20,4 +20,3 @@ class AnalysesRequest(BaseModel):
     comment: list[str] | None = []
     order_id: int | None = Field(alias="orderId", default=None)
     case_id: str | None = None
-    most_recent: bool | None = None

--- a/trailblazer/dto/analyses_request.py
+++ b/trailblazer/dto/analyses_request.py
@@ -19,3 +19,5 @@ class AnalysesRequest(BaseModel):
     type: list[TrailblazerTypes] | None = []
     comment: list[str] | None = []
     order_id: int | None = Field(alias="orderId", default=None)
+    case_id: str | None = None
+    most_recent: bool | None = None

--- a/trailblazer/store/base.py
+++ b/trailblazer/store/base.py
@@ -63,8 +63,6 @@ class BaseHandler:
             filters.append(AnalysisFilter.FILTER_BY_TYPES)
         if query.case_id:
             filters.append(AnalysisFilter.FILTER_BY_CASE_ID)
-        if query.most_recent:
-            filters.append(AnalysisFilter.FILTER_BY_MOST_RECENT)
 
         return apply_analysis_filter(
             filter_functions=filters,

--- a/trailblazer/store/base.py
+++ b/trailblazer/store/base.py
@@ -61,6 +61,10 @@ class BaseHandler:
             filters.append(AnalysisFilter.FILTER_BY_STATUSES)
         if query.type:
             filters.append(AnalysisFilter.FILTER_BY_TYPES)
+        if query.case_id:
+            filters.append(AnalysisFilter.FILTER_BY_CASE_ID)
+        if query.most_recent:
+            filters.append(AnalysisFilter.FILTER_BY_MOST_RECENT)
 
         return apply_analysis_filter(
             filter_functions=filters,
@@ -70,6 +74,7 @@ class BaseHandler:
             priorities=query.priority,
             statuses=query.status,
             types=query.type,
+            case_id=query.case_id,
         )
 
     def get_visible_analyses(self, analyses: Query) -> Query:

--- a/trailblazer/store/filters/analyses_filters.py
+++ b/trailblazer/store/filters/analyses_filters.py
@@ -80,6 +80,10 @@ def filter_analyses_by_empty_comment(analyses: Query, **kwargs) -> Query:
     return analyses.filter(sqlalchemy.or_(Analysis.comment.is_(None), Analysis.comment == ""))
 
 
+def filter_analyses_by_most_recent(analyses: Query, **kwargs) -> Query:
+    return analyses.order_by(Analysis.started_at.desc()).limit(1)
+
+
 class AnalysisFilter(Enum):
     """Define Analysis filter functions."""
 
@@ -96,6 +100,7 @@ class AnalysisFilter(Enum):
     FILTER_BY_STATUS: Callable = filter_analyses_by_status
     FILTER_BY_STATUSES: Callable = filter_analyses_by_statuses
     FILTER_BY_TYPES: Callable = filter_analyses_by_types
+    FILTER_BY_MOST_RECENT: Callable = filter_analyses_by_most_recent
 
 
 def apply_analysis_filter(

--- a/trailblazer/store/filters/analyses_filters.py
+++ b/trailblazer/store/filters/analyses_filters.py
@@ -80,10 +80,6 @@ def filter_analyses_by_empty_comment(analyses: Query, **kwargs) -> Query:
     return analyses.filter(sqlalchemy.or_(Analysis.comment.is_(None), Analysis.comment == ""))
 
 
-def filter_analyses_by_most_recent(analyses: Query, **kwargs) -> Query:
-    return analyses.order_by(Analysis.started_at.desc()).limit(1)
-
-
 class AnalysisFilter(Enum):
     """Define Analysis filter functions."""
 
@@ -100,7 +96,6 @@ class AnalysisFilter(Enum):
     FILTER_BY_STATUS: Callable = filter_analyses_by_status
     FILTER_BY_STATUSES: Callable = filter_analyses_by_statuses
     FILTER_BY_TYPES: Callable = filter_analyses_by_types
-    FILTER_BY_MOST_RECENT: Callable = filter_analyses_by_most_recent
 
 
 def apply_analysis_filter(


### PR DESCRIPTION
## Description
Additional filter parameter on the `/analyses` endpoint required by https://github.com/Clinical-Genomics/cg/pull/2895.

### Added
- Filtering analyses on case id

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
