### PR TITLE
Add order_id when creating analysis

### DIFF
--- a/tests/integration/endpoints/test_add_pending_analysis.py
+++ b/tests/integration/endpoints/test_add_pending_analysis.py
@@ -1,7 +1,8 @@
-from flask.testing import FlaskClient
 from http import HTTPStatus
-from trailblazer.constants import TrailblazerPriority, TrailblazerTypes
 
+from flask.testing import FlaskClient
+
+from trailblazer.constants import TrailblazerPriority, TrailblazerTypes
 from trailblazer.dto.create_analysis_request import CreateAnalysisRequest
 from trailblazer.store.store import Store
 
@@ -17,6 +18,7 @@ def test_adding_analysis(client: FlaskClient, store: Store):
         priority=TrailblazerPriority.NORMAL,
         out_dir="out_dir",
         ticket_id="ticket_id",
+        order_id=123,
     )
     data: str = create_analysis_request.model_dump_json()
 

--- a/trailblazer/dto/create_analysis_request.py
+++ b/trailblazer/dto/create_analysis_request.py
@@ -8,6 +8,7 @@ class CreateAnalysisRequest(BaseModel):
     email: str | None = None
     config_path: str
     out_dir: str
+    order_id: int | None = None
     priority: TrailblazerPriority
     data_analysis: TrailblazerTypes | None = None
     ticket_id: str | None = None

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -21,6 +21,7 @@ class CreateHandler(BaseHandler):
             data_analysis=analysis_data.data_analysis,
             case_id=analysis_data.case_id,
             out_dir=analysis_data.out_dir,
+            order_id=analysis_data.order_id,
             priority=analysis_data.priority,
             started_at=datetime.now(),
             status=TrailblazerStatus.PENDING,


### PR DESCRIPTION
## Description

This PR makes adding the order_id to the add_pending_analysis request possible.

### Changed

- order_id is now a parameter in add_pending_analysis

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
