### PR TITLE
Fix job serialization

### DIFF
--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -16,9 +16,9 @@ class User(BaseModel):
 class Job(BaseModel):
     analysis_id: int
     context: str | None = None
-    elapsed: int
+    elapsed: int | None = None
     id: int
-    name: str
+    name: str | None = None
     slurm_id: int
     started_at: datetime | None = None
     status: str


### PR DESCRIPTION
## Description
The name and elapsed time can be none for a job. These are set when the information is read from slurm.

### Fixed
- Job serialization

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
