### PR TITLE
Fix filtering of balsamic cases

### DIFF
--- a/trailblazer/store/base.py
+++ b/trailblazer/store/base.py
@@ -45,7 +45,7 @@ class BaseHandler:
         balsamic_pipeline: str = Pipeline.BALSAMIC.lower()
         if pipeline == balsamic_pipeline:
             analyses = analyses.filter(Analysis.data_analysis.startswith(balsamic_pipeline))
-        if pipeline:
+        elif pipeline:
             analyses = analyses.filter(Analysis.data_analysis == pipeline)
         return analyses
 


### PR DESCRIPTION
## Description

As highlighted by KS in https://github.com/Clinical-Genomics/cigrid-ui/issues/507, the balsamic filtering is not done properly and the intended balsamic filtering is overridden by a badly placed "if". This PR remedies that. 

### Fixed

- balsamic-pon and balsamic-qc are returned when setting the pipeline to balsamic in analyses.

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b fix-balsamic-filtering -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
