### PR TITLE
Do not filter out other balsamic cases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,7 @@ from typing import Dict, Generator
 import pytest
 from sqlalchemy.orm import Session
 
-from tests.apps.tower.conftest import (
-    TOWER_ID,
-    CaseId,
-    TowerResponseFile,
-    TowerTaskResponseFile,
-)
+from tests.apps.tower.conftest import TOWER_ID, CaseId, TowerResponseFile, TowerTaskResponseFile
 from tests.mocks.store_mock import MockStore
 from tests.store.utils.store_helper import StoreHelpers
 from trailblazer.apps.tower.models import TowerTask
@@ -189,6 +184,21 @@ def analysis_store(
         raw_analysis["case_id"] = raw_analysis.pop("case_id")
         session.add(Analysis(**raw_analysis))
     yield store
+
+
+@pytest.fixture
+def balsamic_case_id() -> str:
+    return "lateraligator"
+
+
+@pytest.fixture
+def balsamic_qc_case_id() -> str:
+    return "assumedcrocodile"
+
+
+@pytest.fixture
+def mip_dna_case_id() -> str:
+    return "escapedgoat"
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/analysis-data.yaml
+++ b/tests/fixtures/analysis-data.yaml
@@ -82,6 +82,17 @@ analyses:
     user: tom.cruise@magnolia.com
     workflow: BALSAMIC
 
+  - case_id: assumedcrocodile
+    version: v4.2.0
+    started_at: 2017-06-15T11:00:42
+    status: pending
+    priority: low
+    out_dir: fixtures/runs/politesnake/analysis
+    config_path: fixtures/runs/politesnake/analysis/politesnake_config.yaml
+    type: wes
+    user: tom.cruise@magnolia.com
+    workflow: BALSAMIC-QC
+
   - case_id: escapedgoat
     version: v3.6.0
     started_at: 2017-06-17T12:11:42

--- a/trailblazer/store/base.py
+++ b/trailblazer/store/base.py
@@ -7,10 +7,7 @@ from sqlalchemy.orm import Query, Session
 from trailblazer.constants import Workflow
 from trailblazer.dto import AnalysesRequest
 from trailblazer.store.database import get_session
-from trailblazer.store.filters.analyses_filters import (
-    AnalysisFilter,
-    apply_analysis_filter,
-)
+from trailblazer.store.filters.analyses_filters import AnalysisFilter, apply_analysis_filter
 from trailblazer.store.models import Analysis, Job, Model
 
 
@@ -48,7 +45,7 @@ class BaseHandler:
         balsamic_workflow: str = Workflow.BALSAMIC.lower()
         if workflow == balsamic_workflow:
             analyses = analyses.filter(Analysis.workflow.startswith(balsamic_workflow))
-        if workflow:
+        elif workflow:
             analyses = analyses.filter(Analysis.workflow == workflow)
         return analyses
 


### PR DESCRIPTION
## Description

A fix applied in #394 has unfortunately been reverted. This re-reverts it and fixes the filter again. Closes https://github.com/Clinical-Genomics/cigrid-ui/issues/507.

### Fixed

- Filtering on balsamic does not filter out balsamic-qc etc.

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
