### PR TITLE
(Streamline delivery) Add delivery table and edit via PUT and PATCH

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 21.2.1
+current_version = 21.2.2
 commit = True
 tag = True
 tag_name = {new_version}

--- a/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
+++ b/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
@@ -45,7 +45,7 @@ def upgrade():
             unique=True,
         ),
         sa.Column("user_id", sa.ForeignKey(User.id), nullable=False),
-        sa.Column("delivered_date", sa.DateTime, nullable=False),
+        sa.Column("delivered_date", sa.Date, nullable=False),
     )
 
 

--- a/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
+++ b/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
@@ -1,0 +1,48 @@
+"""Add delivery table
+
+Revision ID: a8ae3ab67bc8
+Revises: febdb4e78bb5
+Create Date: 2024-03-12 13:54:57.421263
+
+"""
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+# revision identifiers, used by Alembic.
+revision = "a8ae3ab67bc8"
+down_revision = "febdb4e78bb5"
+branch_labels = None
+depends_on = None
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Analysis(Base):
+    __tablename__ = "analysis"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+
+class User(Base):
+    __tablename__ = "user"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+
+def upgrade():
+    op.create_table(
+        "delivery",
+        sa.Column("id", sa.Uuid, nullable=False),
+        sa.Column("analysis_id", sa.ForeignKey(Analysis.id, ondelete="CASCADE"), nullable=False),
+        sa.Column("user_id", sa.ForeignKey(User.id), nullable=False),
+        sa.Column("delivered_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table("delivery")

--- a/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
+++ b/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
@@ -44,7 +44,7 @@ def upgrade():
             nullable=False,
             unique=True,
         ),
-        sa.Column("user_id", sa.ForeignKey(User.id), nullable=False),
+        sa.Column("delivered_by", sa.ForeignKey(User.id), nullable=False),
         sa.Column("delivered_date", sa.Date, nullable=False),
     )
 

--- a/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
+++ b/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
@@ -38,7 +38,12 @@ def upgrade():
     op.create_table(
         "delivery",
         sa.Column("id", sa.Uuid, nullable=False),
-        sa.Column("analysis_id", sa.ForeignKey(Analysis.id, ondelete="CASCADE"), nullable=False),
+        sa.Column(
+            "analysis_id",
+            sa.ForeignKey(Analysis.id, ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
         sa.Column("user_id", sa.ForeignKey(User.id), nullable=False),
         sa.Column("delivered_at", sa.DateTime, nullable=False),
     )

--- a/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
+++ b/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
@@ -45,7 +45,7 @@ def upgrade():
             unique=True,
         ),
         sa.Column("user_id", sa.ForeignKey(User.id), nullable=False),
-        sa.Column("delivered_at", sa.DateTime, nullable=False),
+        sa.Column("delivered_date", sa.DateTime, nullable=False),
     )
 
 

--- a/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
+++ b/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
@@ -5,6 +5,7 @@ Revises: febdb4e78bb5
 Create Date: 2024-03-12 13:54:57.421263
 
 """
+
 import sqlalchemy as sa
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 

--- a/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
+++ b/alembic/versions/2024_03_12_a8ae3ab67bc8_add_delivery_table.py
@@ -5,17 +5,16 @@ Revises: febdb4e78bb5
 Create Date: 2024-03-12 13:54:57.421263
 
 """
+import sqlalchemy as sa
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a8ae3ab67bc8"
 down_revision = "febdb4e78bb5"
 branch_labels = None
 depends_on = None
-
-import sqlalchemy as sa
-
-from alembic import op
 
 
 class Base(DeclarativeBase):

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ except FileNotFoundError:
 
 setup(
     name=NAME,
-    version="21.2.1",
+    version="21.2.2",
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",

--- a/tests/integration/endpoints/test_patching_analyses.py
+++ b/tests/integration/endpoints/test_patching_analyses.py
@@ -1,12 +1,9 @@
 from http import HTTPStatus
-from unittest import mock
 
-from flask import g
 from flask.testing import FlaskClient
 
-import trailblazer.server.api
 from trailblazer.dto.update_analyses import AnalysisUpdate, UpdateAnalyses
-from trailblazer.store.models import Analysis, User
+from trailblazer.store.models import Analysis
 
 
 def test_patch_analysis(client: FlaskClient, analysis: Analysis):

--- a/tests/integration/endpoints/test_patching_analyses.py
+++ b/tests/integration/endpoints/test_patching_analyses.py
@@ -13,16 +13,15 @@ def test_patch_analysis(client: FlaskClient, analysis: Analysis):
     # GIVEN an analysis
 
     # GIVEN a valid request to pach the analysis
-    update = AnalysisUpdate(id=analysis.id, comment="new_comment")
+    update = AnalysisUpdate(id=analysis.id, comment="new_comment", delivered=True)
     request = UpdateAnalyses(analyses=[update])
     data: str = request.model_dump_json()
 
-    with mock.patch.object(trailblazer.server.api, "before_request", return_value=None):
-        # WHEN patching the analysis
-        response = client.patch("/api/v1/analyses", data=data, content_type="application/json")
+    # WHEN patching the analysis
+    response = client.patch("/api/v1/analyses", data=data, content_type="application/json")
 
-        # THEN it gives a success response
-        assert response.status_code == HTTPStatus.OK
+    # THEN it gives a success response
+    assert response.status_code == HTTPStatus.OK
 
-        # THEN it should return the analysis
-        assert response.json["analyses"]
+    # THEN it should return the analysis
+    assert response.json["analyses"]

--- a/tests/integration/endpoints/test_patching_analyses.py
+++ b/tests/integration/endpoints/test_patching_analyses.py
@@ -1,7 +1,11 @@
-from flask.testing import FlaskClient
 from http import HTTPStatus
-from trailblazer.dto.update_analyses import AnalysisUpdate, UpdateAnalyses
+from unittest import mock
 
+from flask import g
+from flask.testing import FlaskClient
+
+import trailblazer.server.api
+from trailblazer.dto.update_analyses import AnalysisUpdate, UpdateAnalyses
 from trailblazer.store.models import Analysis
 
 
@@ -13,11 +17,12 @@ def test_patch_analysis(client: FlaskClient, analysis: Analysis):
     request = UpdateAnalyses(analyses=[update])
     data: str = request.model_dump_json()
 
-    # WHEN patching the analysis
-    response = client.patch("/api/v1/analyses", data=data, content_type="application/json")
+    with mock.patch.object(trailblazer.server.api, "before_request", return_value=None):
+        # WHEN patching the analysis
+        response = client.patch("/api/v1/analyses", data=data, content_type="application/json")
 
-    # THEN it gives a success response
-    assert response.status_code == HTTPStatus.OK
+        # THEN it gives a success response
+        assert response.status_code == HTTPStatus.OK
 
-    # THEN it should return the analysis
-    assert response.json["analyses"]
+        # THEN it should return the analysis
+        assert response.json["analyses"]

--- a/tests/integration/endpoints/test_patching_analyses.py
+++ b/tests/integration/endpoints/test_patching_analyses.py
@@ -6,14 +6,14 @@ from flask.testing import FlaskClient
 
 import trailblazer.server.api
 from trailblazer.dto.update_analyses import AnalysisUpdate, UpdateAnalyses
-from trailblazer.store.models import Analysis
+from trailblazer.store.models import Analysis, User
 
 
 def test_patch_analysis(client: FlaskClient, analysis: Analysis):
     # GIVEN an analysis
 
     # GIVEN a valid request to pach the analysis
-    update = AnalysisUpdate(id=analysis.id, comment="new_comment", delivered=True)
+    update = AnalysisUpdate(id=analysis.id, comment="new_comment")
     request = UpdateAnalyses(analyses=[update])
     data: str = request.model_dump_json()
 

--- a/tests/integration/services/conftest.py
+++ b/tests/integration/services/conftest.py
@@ -45,7 +45,6 @@ def encryption_service() -> EncryptionService:
 
 @pytest.fixture
 def google_oauth_client(google_oauth_response: dict, mock_request: Mocker) -> GoogleOAuthClient:
-
     oauth_base_url = "https://oauth2.googleapis.com/token"
     mock_request.post(oauth_base_url, json=google_oauth_response)
 

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from trailblazer.services.analysis_service.analysis_service import AnalysisService
+from trailblazer.store.store import Store
+
+
+@pytest.fixture
+def analysis_service(analysis_store: Store) -> AnalysisService:
+    return AnalysisService(analysis_store)

--- a/tests/services/test_analysis_service.py
+++ b/tests/services/test_analysis_service.py
@@ -1,0 +1,17 @@
+from trailblazer.dto.update_analyses import AnalysisUpdate, UpdateAnalyses
+from trailblazer.services.analysis_service.analysis_service import AnalysisService
+from trailblazer.store.models import Analysis, User
+from trailblazer.store.store import Store
+
+
+def test_patch_analyses_delivered(
+    analysis_store: Store, analysis_id: int, analysis_service: AnalysisService
+):
+    analysis: Analysis = analysis_store.get_analysis_with_id(analysis_id)
+    analysis_update = AnalysisUpdate(id=analysis_id, delivered=True)
+    update_analyses = UpdateAnalyses(analyses=[analysis_update])
+    user = User(id=1)
+
+    analysis_service.update_analyses(data=update_analyses, user=user)
+
+    assert analysis.delivered_by

--- a/tests/services/test_analysis_service.py
+++ b/tests/services/test_analysis_service.py
@@ -8,7 +8,7 @@ def test_patch_analyses_delivered(
     analysis_store: Store, analysis_id: int, analysis_service: AnalysisService
 ):
     analysis: Analysis = analysis_store.get_analysis_with_id(analysis_id)
-    analysis_update = AnalysisUpdate(id=analysis_id, delivered=True)
+    analysis_update = AnalysisUpdate(id=analysis_id, is_delivered=True)
     update_analyses = UpdateAnalyses(analyses=[analysis_update])
     user = User(id=1)
 

--- a/trailblazer/clients/authentication_client/google_oauth_client.py
+++ b/trailblazer/clients/authentication_client/google_oauth_client.py
@@ -9,7 +9,6 @@ from trailblazer.clients.authentication_client.exceptions import GoogleOAuthClie
 
 
 class GoogleOAuthClient:
-
     def __init__(self, client_id: str, client_secret: str, redirect_uri: str, oauth_base_url: str):
         self.client_id = client_id
         self.client_secret = client_secret

--- a/trailblazer/clients/google_api_client/google_api_client.py
+++ b/trailblazer/clients/google_api_client/google_api_client.py
@@ -4,7 +4,6 @@ from trailblazer.clients.google_api_client.exceptions import GoogleAPIClientErro
 
 
 class GoogleAPIClient:
-
     def __init__(self, base_url: str):
         self.base_url = base_url
 

--- a/trailblazer/dto/analyses_response.py
+++ b/trailblazer/dto/analyses_response.py
@@ -18,7 +18,7 @@ class Analysis(BaseModel):
     comment: str | None = None
     completed_at: datetime | None = None
     config_path: str | None = None
-    delivered: bool | None = None
+    is_delivered: bool | None = None
     workflow: str | None = None
     failed_job: Job | None = None
     id: int

--- a/trailblazer/dto/analyses_response.py
+++ b/trailblazer/dto/analyses_response.py
@@ -18,6 +18,7 @@ class Analysis(BaseModel):
     comment: str | None = None
     completed_at: datetime | None = None
     config_path: str | None = None
+    delivered: bool | None = None
     workflow: str | None = None
     failed_job: Job | None = None
     id: int

--- a/trailblazer/dto/analysis_update_request.py
+++ b/trailblazer/dto/analysis_update_request.py
@@ -5,6 +5,6 @@ from trailblazer.constants import TrailblazerStatus
 
 class AnalysisUpdateRequest(BaseModel):
     comment: str | None = None
-    delivered: bool | None = None
+    is_delivered: bool | None = None
     is_visible: bool | None = None
     status: TrailblazerStatus | None = None

--- a/trailblazer/dto/analysis_update_request.py
+++ b/trailblazer/dto/analysis_update_request.py
@@ -4,6 +4,7 @@ from trailblazer.constants import TrailblazerStatus
 
 
 class AnalysisUpdateRequest(BaseModel):
-    is_visible: bool | None = None
     comment: str | None = None
+    delivered: bool | None = None
+    is_visible: bool | None = None
     status: TrailblazerStatus | None = None

--- a/trailblazer/dto/update_analyses.py
+++ b/trailblazer/dto/update_analyses.py
@@ -7,7 +7,7 @@ class AnalysisUpdate(BaseModel):
     id: int
 
     comment: str | None = None
-    delivered: bool | None = None
+    is_delivered: bool | None = None
     is_visible: bool | None = None
     status: TrailblazerStatus | None = None
 

--- a/trailblazer/dto/update_analyses.py
+++ b/trailblazer/dto/update_analyses.py
@@ -5,9 +5,11 @@ from trailblazer.constants import TrailblazerStatus
 
 class AnalysisUpdate(BaseModel):
     id: int
-    status: TrailblazerStatus | None = None
+
     comment: str | None = None
+    delivered: bool | None = None
     is_visible: bool | None = None
+    status: TrailblazerStatus | None = None
 
 
 class UpdateAnalyses(BaseModel):

--- a/trailblazer/dto/update_analyses.py
+++ b/trailblazer/dto/update_analyses.py
@@ -5,7 +5,6 @@ from trailblazer.constants import TrailblazerStatus
 
 class AnalysisUpdate(BaseModel):
     id: int
-
     comment: str | None = None
     is_delivered: bool | None = None
     is_visible: bool | None = None

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -144,8 +144,9 @@ def update_analysis(
 ):
     try:
         request_data = AnalysisUpdateRequest.model_validate(request.json)
+        user: User = g.get("current_user")
         response: AnalysisResponse = analysis_service.update_analysis(
-            analysis_id=analysis_id, update=request_data
+            analysis_id=analysis_id, update=request_data, user=user
         )
         return jsonify(response.model_dump()), HTTPStatus.OK
     except MissingAnalysis as error:

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from http import HTTPStatus
 from typing import Mapping
@@ -100,7 +101,7 @@ def patch_analyses(analysis_service: AnalysisService = Provide[Container.analysi
     """Update data (such as status, visibility, comments etc.) for multiple analyses at once."""
     try:
         request_data = UpdateAnalyses.model_validate(request.json)
-        user = g.get("current_user")
+        user: User = g.get("current_user")
         response: UpdateAnalysesResponse = analysis_service.update_analyses(
             data=request_data, user=user
         )

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -100,8 +100,9 @@ def patch_analyses(analysis_service: AnalysisService = Provide[Container.analysi
     """Update data (such as status, visibility, comments etc.) for multiple analyses at once."""
     try:
         request_data = UpdateAnalyses.model_validate(request.json)
+        user = g.get("current_user")
         response: UpdateAnalysesResponse = analysis_service.update_analyses(
-            data=request_data, user=g.current_user
+            data=request_data, user=user
         )
         return jsonify(response.model_dump()), HTTPStatus.OK
     except ValidationError as error:

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -2,18 +2,10 @@ import os
 from http import HTTPStatus
 from typing import Mapping
 
-from flask import (
-    Blueprint,
-    Response,
-    abort,
-    g,
-    jsonify,
-    make_response,
-    request,
-)
+from dependency_injector.wiring import Provide, inject
+from flask import Blueprint, Response, abort, g, jsonify, make_response, request
 from google.auth import jwt
 from pydantic import ValidationError
-from dependency_injector.wiring import inject, Provide
 
 from trailblazer.containers import Container
 from trailblazer.dto import (
@@ -22,9 +14,9 @@ from trailblazer.dto import (
     AnalysisResponse,
     AnalysisUpdateRequest,
     CreateJobRequest,
-    JobResponse,
     FailedJobsRequest,
     FailedJobsResponse,
+    JobResponse,
 )
 from trailblazer.dto.analyses_response import UpdateAnalysesResponse
 from trailblazer.dto.authentication.code_exchange_request import CodeExchangeRequest
@@ -34,10 +26,7 @@ from trailblazer.dto.summaries_response import SummariesResponse
 from trailblazer.dto.update_analyses import UpdateAnalyses
 from trailblazer.exc import MissingAnalysis
 from trailblazer.server.ext import store
-from trailblazer.server.utils import (
-    parse_analyses_request,
-    stringify_timestamps,
-)
+from trailblazer.server.utils import parse_analyses_request, stringify_timestamps
 from trailblazer.services.analysis_service.analysis_service import AnalysisService
 from trailblazer.services.authentication_service.authentication_service import AuthenticationService
 from trailblazer.services.authentication_service.exceptions import AuthenticationError
@@ -111,7 +100,9 @@ def patch_analyses(analysis_service: AnalysisService = Provide[Container.analysi
     """Update data (such as status, visibility, comments etc.) for multiple analyses at once."""
     try:
         request_data = UpdateAnalyses.model_validate(request.json)
-        response: UpdateAnalysesResponse = analysis_service.update_analyses(request_data)
+        response: UpdateAnalysesResponse = analysis_service.update_analyses(
+            data=request_data, user=g.current_user
+        )
         return jsonify(response.model_dump()), HTTPStatus.OK
     except ValidationError as error:
         return jsonify(error=str(error)), HTTPStatus.BAD_REQUEST

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -15,7 +15,7 @@ from trailblazer.services.analysis_service.utils import (
     create_summary,
     create_update_analyses_response,
 )
-from trailblazer.store.models import Analysis, Job
+from trailblazer.store.models import Analysis, Job, User
 from trailblazer.store.store import Store
 
 
@@ -43,8 +43,10 @@ class AnalysisService:
         )
         return create_analysis_response(analysis)
 
-    def update_analyses(self, data: UpdateAnalyses) -> UpdateAnalysesResponse:
-        analyses: list[Analysis] = self.store.update_analyses(data)
+    def update_analyses(
+        self, data: UpdateAnalyses, user: User | None = None
+    ) -> UpdateAnalysesResponse:
+        analyses: list[Analysis] = self.store.update_analyses(data=data, user=user)
         return create_update_analyses_response(analyses)
 
     def add_pending_analysis(self, request_data: CreateAnalysisRequest) -> AnalysisResponse:

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -34,12 +34,16 @@ class AnalysisService:
             raise MissingAnalysis(f"Analysis with id: {analysis_id} not found")
         return create_analysis_response(analysis)
 
-    def update_analysis(self, analysis_id: int, update: AnalysisUpdateRequest) -> AnalysisResponse:
+    def update_analysis(
+        self, analysis_id: int, update: AnalysisUpdateRequest, user: User | None = None
+    ) -> AnalysisResponse:
         analysis: Analysis = self.store.update_analysis(
             analysis_id=analysis_id,
             comment=update.comment,
+            delivered=update.delivered,
             status=update.status,
             is_visible=update.is_visible,
+            user=user,
         )
         return create_analysis_response(analysis)
 

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -40,7 +40,7 @@ class AnalysisService:
         analysis: Analysis = self.store.update_analysis(
             analysis_id=analysis_id,
             comment=update.comment,
-            delivered=update.delivered,
+            is_delivered=update.is_delivered,
             status=update.status,
             is_visible=update.is_visible,
             user=user,

--- a/trailblazer/services/authentication_service/authentication_service.py
+++ b/trailblazer/services/authentication_service/authentication_service.py
@@ -8,7 +8,6 @@ from trailblazer.store.store import Store
 
 
 class AuthenticationService:
-
     def __init__(
         self,
         google_oauth_client: GoogleOAuthClient,

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -239,7 +239,9 @@ class UpdateHandler(BaseHandler):
     ) -> None:
         if delivered:
             analysis.delivery = Delivery(
-                analysis_id=analysis.id, delivered_date=datetime.today(), user_id=user.id
+                analysis_id=analysis.id,
+                delivered_by=user.id,
+                delivered_date=datetime.today(),
             )
         else:
             if delivery := analysis.delivery:

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -237,15 +237,18 @@ class UpdateHandler(BaseHandler):
     def update_analysis_delivery(
         analysis: Analysis, delivered: bool, user: User | None = None
     ) -> None:
+        session: Session = get_session()
         if delivered:
-            analysis.delivery = Delivery(
+            delivery = Delivery(
                 analysis_id=analysis.id,
                 delivered_by=user.id,
                 delivered_date=datetime.today(),
             )
+            session.add(delivery)
+            session.commit()
+            analysis.delivery = delivery
         else:
             if delivery := analysis.delivery:
-                session: Session = get_session()
                 session.delete(delivery)
 
     def update_analysis(

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -287,6 +287,7 @@ class UpdateHandler(BaseHandler):
         for analysis_update in data.analyses:
             analysis: Analysis = self.update_analysis(
                 analysis_id=analysis_update.id,
+                delivered=analysis_update.delivered,
                 comment=analysis_update.comment,
                 is_visible=analysis_update.is_visible,
                 status=analysis_update.status,

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -92,7 +92,6 @@ class Analysis(Model):
     workflow_manager = Column(types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM)
 
     jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
-    delivery = orm.relationship("Delivery", back_populates="analysis")
 
     @property
     def has_ongoing_status(self) -> bool:
@@ -157,8 +156,8 @@ class Delivery(Model):
     delivered_by = Column(ForeignKey(User.id), nullable=False)
     delivered_date = Column(types.DateTime, nullable=False)
 
-    analysis = orm.relationship("Analysis", back_populates="delivery")
-    user = orm.relationship("User")
+    analysis = orm.relationship("Analysis", foreign_keys=[analysis_id])
+    user = orm.relationship("User", foreign_keys=[delivered_by])
 
 
 class Job(Model):

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -92,7 +92,7 @@ class Analysis(Model):
     workflow_manager = Column(types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM)
 
     jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
-    delivery = orm.relationship("Delivery", backref="analysis")
+    delivery = orm.relationship("Delivery", back_populates="analysis")
 
     @property
     def has_ongoing_status(self) -> bool:
@@ -154,7 +154,7 @@ class Delivery(Model):
     delivered_by = Column(ForeignKey(User.id), nullable=False)
     delivered_date = Column(types.DateTime, nullable=False)
 
-    delivery = orm.relationship("Analysis", back_populates="delivery")
+    analysis = orm.relationship("Analysis", back_populates="delivery")
     user = orm.relationship("User")
 
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -122,6 +122,9 @@ class Analysis(Model):
         return {
             "id": self.id,
             "case_id": self.case_id,
+            "delivered": bool(self.delivery),
+            "delivered_by": self.delivered_by,
+            "delivered_date": self.delivered_date,
             "version": self.version,
             "logged_at": self.logged_at,
             "started_at": self.started_at,

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -111,7 +111,7 @@ class Analysis(Model):
 
     @property
     def delivered_by(self) -> User | None:
-        return self.delivery.user if self.delivery else None
+        return self.delivery.delivered_by if self.delivery else None
 
     @property
     def delivered_date(self) -> datetime.datetime | None:

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -134,6 +134,18 @@ class Analysis(Model):
         }
 
 
+class Delivery(Model):
+    """Tracks when and by whom an analysis was delivered."""
+
+    __tablename__ = "delivery"
+    __table_args__ = (UniqueConstraint("analysis_id"),)
+
+    id = Column(types.Uuid, primary_key=True)
+    analysis_id = Column(ForeignKey(Analysis.id, ondelete="CASCADE"), nullable=False)
+    delivered_by = Column(ForeignKey(User.id), nullable=False)
+    delivered_date = Column(types.DateTime, nullable=False)
+
+
 class Job(Model):
     """Represent a step in the workflow."""
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -92,7 +92,7 @@ class Analysis(Model):
     workflow_manager = Column(types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM)
 
     jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
-
+    delivery = orm.relationship("Delivery", backref="analysis")
     @property
     def has_ongoing_status(self) -> bool:
         """Check if analysis status is ongoing."""
@@ -107,6 +107,14 @@ class Analysis(Model):
     def upload_jobs(self) -> list["Job"]:
         """Return upload jobs."""
         return [job for job in self.jobs if job.job_type == JobType.UPLOAD]
+
+    @property
+    def delivered_by(self) -> User:
+        return self.delivery.user
+
+    @property
+    def delivered_date(self) -> datetime:
+        return self.delivery.delivered_date
 
     def to_dict(self) -> dict:
         """Return a dictionary representation of the object."""
@@ -144,6 +152,9 @@ class Delivery(Model):
     analysis_id = Column(ForeignKey(Analysis.id, ondelete="CASCADE"), nullable=False)
     delivered_by = Column(ForeignKey(User.id), nullable=False)
     delivered_date = Column(types.DateTime, nullable=False)
+
+    analysis = orm.relationship("Analysis", backref="delivery")
+    user = orm.relationship("User")
 
 
 class Job(Model):

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -154,7 +154,7 @@ class Delivery(Model):
     delivered_by = Column(ForeignKey(User.id), nullable=False)
     delivered_date = Column(types.DateTime, nullable=False)
 
-    analysis = orm.relationship("Analysis", backref="delivery")
+    delivery = orm.relationship("Analysis", back_populates="delivery")
     user = orm.relationship("User")
 
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -110,12 +110,12 @@ class Analysis(Model):
         return [job for job in self.jobs if job.job_type == JobType.UPLOAD]
 
     @property
-    def delivered_by(self) -> User:
-        return self.delivery.user
+    def delivered_by(self) -> User | None:
+        return self.delivery.user if self.delivery else None
 
     @property
-    def delivered_date(self) -> datetime:
-        return self.delivery.delivered_date
+    def delivered_date(self) -> datetime.datetime | None:
+        return self.delivery.delivered_date if self.delivery else None
 
     def to_dict(self) -> dict:
         """Return a dictionary representation of the object."""

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -123,7 +123,7 @@ class Analysis(Model):
         return {
             "id": self.id,
             "case_id": self.case_id,
-            "delivered": bool(self.delivery),
+            "is_delivered": bool(self.delivery),
             "delivered_by": self.delivered_by,
             "delivered_date": self.delivered_date,
             "version": self.version,

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 from sqlalchemy import Column, ForeignKey, UniqueConstraint, orm, types
 
@@ -92,6 +93,7 @@ class Analysis(Model):
     workflow_manager = Column(types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM)
 
     jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
+    delivery = orm.relationship("Delivery", uselist=False)
 
     @property
     def has_ongoing_status(self) -> bool:
@@ -151,12 +153,12 @@ class Delivery(Model):
     __tablename__ = "delivery"
     __table_args__ = (UniqueConstraint("analysis_id"),)
 
-    id = Column(types.Uuid, primary_key=True)
+    id = Column(types.Uuid, primary_key=True, default=uuid.uuid4)
     analysis_id = Column(ForeignKey(Analysis.id, ondelete="CASCADE"), nullable=False)
     delivered_by = Column(ForeignKey(User.id), nullable=False)
     delivered_date = Column(types.DateTime, nullable=False)
 
-    analysis = orm.relationship("Analysis", foreign_keys=[analysis_id])
+    analysis = orm.relationship("Analysis", foreign_keys=[analysis_id], back_populates="delivery")
     user = orm.relationship("User", foreign_keys=[delivered_by])
 
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -93,6 +93,7 @@ class Analysis(Model):
 
     jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
     delivery = orm.relationship("Delivery", backref="analysis")
+
     @property
     def has_ongoing_status(self) -> bool:
         """Check if analysis status is ongoing."""


### PR DESCRIPTION
## Description

We wish to stop marking analyses as delivered by writing comments. This PR adds a table for tracking 
- Who delivered the analysis
- When it was delivered

Closes https://github.com/Clinical-Genomics/streamline-delivery/issues/67.

### Added

- Delivery table

### Changed

- You can set analyses as delivered/undelivered in /analyses and /analyses/<id>

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b add-delivery-table -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
