### PR TITLE
Return id token

### DIFF
--- a/tests/integration/services/conftest.py
+++ b/tests/integration/services/conftest.py
@@ -93,6 +93,7 @@ def google_oauth_response() -> dict:
         "expires_in": 3600,
         "refresh_token": "refresh_token",
         "scope": "scope",
+        "id_token": "id_token",
     }
 
 

--- a/trailblazer/clients/authentication_client/dtos/tokens_response.py
+++ b/trailblazer/clients/authentication_client/dtos/tokens_response.py
@@ -7,3 +7,4 @@ class TokensResponse(BaseModel):
     refresh_token: str
     scope: str
     token_type: str
+    id_token: str

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -75,7 +75,7 @@ def authenticate(auth_service: AuthenticationService = Provide[Container.auth_se
     try:
         request_data = CodeExchangeRequest.model_validate(request.json)
         token: str = auth_service.authenticate(request_data.code)
-        return jsonify({"access_token": token}), HTTPStatus.OK
+        return jsonify({"token": token}), HTTPStatus.OK
     except ValidationError as error:
         return jsonify(error=str(error)), HTTPStatus.BAD_REQUEST
     except AuthenticationError:

--- a/trailblazer/services/authentication_service/authentication_service.py
+++ b/trailblazer/services/authentication_service/authentication_service.py
@@ -22,7 +22,7 @@ class AuthenticationService:
         self.store = store
 
     def authenticate(self, authorization_code: str) -> str:
-        """Exchange the authorization code for an access token."""
+        """Exchange the authorization code for an id token."""
         tokens: TokensResponse = self.google_oauth_client.get_tokens(authorization_code)
         user_email: str = self.google_api_client.get_user_email(tokens.access_token)
         user: User | None = self.store.get_user(user_email)
@@ -33,7 +33,7 @@ class AuthenticationService:
         encrypted_token: str = self.encryption_service.encrypt(tokens.refresh_token)
         self.store.update_user_token(user_id=user.id, refresh_token=encrypted_token)
 
-        return tokens.access_token
+        return tokens.id_token
 
     def refresh_access_token(self, user_id: int) -> str:
         """Refresh the users access token."""


### PR DESCRIPTION
We want to return the `id_token` instead of the access token. The access token is only necessary if we want to access any information about the user via a Google API.

Since we only use the token for authenticating the user, the access token is not needed. We want the token which serves as proof of the users identity.

Adjusts https://github.com/Clinical-Genomics/streamline-delivery/issues/58.