### PR TITLE
(Streamline delivery) Use latest analysis per case

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,20 +17,25 @@ from trailblazer.store.models import Analysis, Job
 
 
 @pytest.fixture
-def analysis() -> Analysis:
+def order_id_with_multiple_analyses() -> int:
+    return 1
+
+
+@pytest.fixture
+def analysis(order_id_with_multiple_analyses) -> Analysis:
     analysis = Analysis(
         config_path="config_path",
         workflow="workflow",
         case_id="case_id",
         out_dir="out_dir",
         priority=PRIORITY_OPTIONS[0],
-        started_at=datetime.datetime.now(),
+        started_at=datetime.datetime.now() - datetime.timedelta(weeks=1),
         status=TrailblazerStatus.PENDING,
         ticket_id="ticket_id",
         type=TYPES[0],
         workflow_manager=WorkflowManager.SLURM,
         is_visible=True,
-        order_id=1,
+        order_id=order_id_with_multiple_analyses,
     )
     session: Session = get_session()
     session.add(analysis)

--- a/tests/integration/endpoints/test_get_summaries.py
+++ b/tests/integration/endpoints/test_get_summaries.py
@@ -1,5 +1,6 @@
-from flask.testing import FlaskClient
 from http import HTTPStatus
+
+from flask.testing import FlaskClient
 
 from trailblazer.store.models import Analysis
 
@@ -13,3 +14,19 @@ def test_get_summaries(client: FlaskClient, analysis: Analysis):
 
     # THEN it gives a success response
     assert response.status_code == HTTPStatus.OK
+
+
+def test_get_summaries_lastest_date(
+    client: FlaskClient,
+    analysis: Analysis,
+    analyses: list[Analysis],
+    order_id_with_multiple_analyses: int,
+):
+    # GIVEN an order with multiple analyses for the same case
+
+    # WHEN requesting a summary for the analyses in the order
+    response = client.get(f"/api/v1/summary?orderIds={order_id_with_multiple_analyses}")
+
+    # THEN it gives a success response
+    assert response.status_code == HTTPStatus.OK
+    assert response.json["summaries"][0]["total"] == 1

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -72,7 +72,7 @@ class AnalysisService:
     def get_summaries(self, request_data: SummariesRequest) -> SummariesResponse:
         summaries: list[Summary] = []
         for order_id in request_data.order_ids:
-            analyses: list[Analysis] = self.store.get_latest_analyses_in_an_order(order_id)
+            analyses: list[Analysis] = self.store.get_latest_analyses_for_order(order_id)
             summary: Summary = create_summary(analyses=analyses, order_id=order_id)
             summaries.append(summary)
         return SummariesResponse(summaries=summaries)

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -72,7 +72,7 @@ class AnalysisService:
     def get_summaries(self, request_data: SummariesRequest) -> SummariesResponse:
         summaries: list[Summary] = []
         for order_id in request_data.order_ids:
-            analyses: list[Analysis] = self.store.get_analyses_by_order_id(order_id)
+            analyses: list[Analysis] = self.store.get_latest_analyses_in_an_order(order_id)
             summary: Summary = create_summary(analyses=analyses, order_id=order_id)
             summaries.append(summary)
         return SummariesResponse(summaries=summaries)

--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -195,7 +195,7 @@ class ReadHandler(BaseHandler):
             job_id=job_id,
         ).first()
 
-    def get_latest_analyses_in_an_order(self, order_id: int) -> list[Analysis]:
+    def get_latest_analyses_for_order(self, order_id: int) -> list[Analysis]:
         """Returns the latest analysis per case in the given order."""
         return apply_analysis_filter(
             analyses=self.get_query(Analysis),

--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -7,10 +7,7 @@ from sqlalchemy.orm import Query
 from trailblazer.constants import JobType, TrailblazerStatus
 from trailblazer.dto.analyses_request import AnalysesRequest
 from trailblazer.store.base import BaseHandler
-from trailblazer.store.filters.analyses_filters import (
-    AnalysisFilter,
-    apply_analysis_filter,
-)
+from trailblazer.store.filters.analyses_filters import AnalysisFilter, apply_analysis_filter
 from trailblazer.store.filters.job_filters import JobFilter, apply_job_filters
 from trailblazer.store.filters.user_filters import UserFilter, apply_user_filter
 from trailblazer.store.models import Analysis, Job, User
@@ -198,10 +195,11 @@ class ReadHandler(BaseHandler):
             job_id=job_id,
         ).first()
 
-    def get_analyses_by_order_id(self, order_id: int) -> list[Analysis]:
+    def get_latest_analyses_in_an_order(self, order_id: int) -> list[Analysis]:
+        """Returns the latest analysis per case in the given order."""
         return apply_analysis_filter(
             analyses=self.get_query(Analysis),
-            filter_functions=[AnalysisFilter.BY_ORDER_ID],
+            filter_functions=[AnalysisFilter.BY_ORDER_ID, AnalysisFilter.BY_LATEST_PER_CASE],
             order_id=order_id,
         ).all()
 

--- a/trailblazer/store/filters/analyses_filters.py
+++ b/trailblazer/store/filters/analyses_filters.py
@@ -134,7 +134,6 @@ def filter_analyses_by_latest_per_case(analyses: Query, **kwargs) -> Query:
             provided_analyses.columns.case_id,
             func.max(provided_analyses.columns.started_at).label("max_started_at"),
         )
-        .select_from(provided_analyses)
         .group_by(provided_analyses.columns.case_id)
         .subquery()
     )

--- a/trailblazer/store/filters/analyses_filters.py
+++ b/trailblazer/store/filters/analyses_filters.py
@@ -130,12 +130,15 @@ def filter_analyses_by_latest_per_case(analyses: Query, **kwargs) -> Query:
     provided_analyses = analyses.subquery()
     session = get_session()
     latest_date_per_case: Subquery = (
-        session.query(Analysis.case_id, func.max(Analysis.started_at).label("max_started_at"))
+        session.query(
+            provided_analyses.columns.case_id,
+            func.max(provided_analyses.columns.started_at).label("max_started_at"),
+        )
         .select_from(provided_analyses)
-        .group_by(Analysis.case_id)
+        .group_by(provided_analyses.columns.case_id)
         .subquery()
     )
-    latest_analysis_per_case: Query = session.query(Analysis).join(
+    latest_analysis_per_case: Query = analyses.join(
         latest_date_per_case,
         (Analysis.case_id == latest_date_per_case.c.case_id)
         & (Analysis.started_at == latest_date_per_case.c.max_started_at),

--- a/trailblazer/store/filters/analyses_filters.py
+++ b/trailblazer/store/filters/analyses_filters.py
@@ -128,7 +128,6 @@ def filter_analyses_by_latest_per_case(analyses: Query, **kwargs) -> Query:
     """
 
     provided_analyses = analyses.subquery()
-    select(Analysis)
     session = get_session()
     latest_date_per_case: Subquery = (
         session.query(Analysis.case_id, func.max(Analysis.started_at).label("max_started_at"))


### PR DESCRIPTION
## Description

When counting analysis statuses within an order, we should only use the latest analysis within each case. This PR adds a filter which makes sure that only the analysis with the latest `started_at` per case is used.

### Added

- Filter by latest_per_case

### Fixed

- Order summaries only use the latest analysis in each case.

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
