### PR TITLE
Make delivery fields nullable

### DIFF
--- a/alembic/versions/2024_03_21_a6a826d2cdc4_make_delivery_fields_nullable.py
+++ b/alembic/versions/2024_03_21_a6a826d2cdc4_make_delivery_fields_nullable.py
@@ -1,0 +1,27 @@
+"""Make delivery fields nullable
+
+Revision ID: a6a826d2cdc4
+Revises: a8ae3ab67bc8
+Create Date: 2024-03-21 14:22:57.012567
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "a6a826d2cdc4"
+down_revision = "a8ae3ab67bc8"
+branch_labels = None
+depends_on = None
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+def upgrade():
+    op.alter_column("delivery", "delivered_by", existing_type=sa.Integer, nullable=True)
+    op.alter_column("delivery", "delivered_date", existing_type=sa.Date, nullable=True)
+
+
+def downgrade():
+    op.alter_column("delivery", "delivered_date", existing_type=sa.Date, nullable=False)
+    op.alter_column("delivery", "delivered_by", existing_type=sa.Integer, nullable=False)

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -155,8 +155,8 @@ class Delivery(Model):
 
     id = Column(types.Uuid, primary_key=True, default=uuid.uuid4)
     analysis_id = Column(ForeignKey(Analysis.id, ondelete="CASCADE"), nullable=False)
-    delivered_by = Column(ForeignKey(User.id), nullable=False)
-    delivered_date = Column(types.Date, nullable=False)
+    delivered_by = Column(ForeignKey(User.id))
+    delivered_date = Column(types.Date)
 
     analysis = orm.relationship("Analysis", foreign_keys=[analysis_id], back_populates="delivery")
     user = orm.relationship("User", foreign_keys=[delivered_by])


### PR DESCRIPTION
## Description

To mark old analyses as delivered it was decided that we do not need to set by whom or when this happened. Hence the entries need to be nullable, so that we can add these old entries.

### Changed

- Delivery.delivered_by and Delivery.delivered_date are nullable.


### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
