### PR TITLE
refactor(foreign key user_id)

### DIFF
--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -155,11 +155,11 @@ class Delivery(Model):
 
     id = Column(types.Uuid, primary_key=True, default=uuid.uuid4)
     analysis_id = Column(ForeignKey(Analysis.id, ondelete="CASCADE"), nullable=False)
-    delivered_by = Column(ForeignKey(User.id), nullable=False)
+    user_id = Column(ForeignKey(User.id), nullable=False)
     delivered_date = Column(types.Date, nullable=False)
 
     analysis = orm.relationship("Analysis", foreign_keys=[analysis_id], back_populates="delivery")
-    user = orm.relationship("User", foreign_keys=[delivered_by])
+    user = orm.relationship("User", foreign_keys=[user_id])
 
 
 class Job(Model):


### PR DESCRIPTION
# Description


refactors a column name in the `Delivery` database model from `delivered_by` to `user_id`.

This is mainly to keep consistency on how we name foreign keys elsewhere and have clearer relationships.

Furthermore, `delivered_by` is already a property on the `Analysis` table. Here it returns a user `name` and not an id. This would be another point of inconcistency.

