### PR TITLE
Refactor logic for updating analyses

### DIFF
--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -15,7 +15,6 @@ from trailblazer.cli.core import (
     get_user_from_db,
     get_users_from_db,
     ls_cmd,
-    scan,
     set_analysis_completed,
     set_analysis_status,
     unarchive_user,
@@ -474,37 +473,6 @@ def test_unarchive_user(
 
     # THEN log shows users as not archived
     assert f"User unarchived: {archived_user_email}" in caplog.text
-
-
-def test_scan(
-    cli_runner: CliRunner,
-    analysis_store: MockStore,
-    caplog,
-    mocker,
-    ongoing_analysis_case_id: str,
-    slurm_squeue_output: dict[str, str],
-    slurm_job_ids: list[int]
-):
-    """Test scanning for analyses and updating analysis status."""
-    caplog.set_level("INFO")
-
-    # GIVEN SLURM squeue output for an analysis
-    mocker.patch("trailblazer.services.job_service.job_service.get_slurm_job_ids", return_value=slurm_job_ids)
-    mocker.patch(
-        FUNC_GET_SLURM_SQUEUE_OUTPUT_PATH,
-        return_value=subprocess.check_output(
-            ["cat", slurm_squeue_output.get(ongoing_analysis_case_id)]
-        ).decode(CharacterFormat.UNICODE_TRANSFORMATION_FORMAT_8),
-    )
-
-    # GIVEN populated Trailblazer database with pending analyses
-
-    # WHEN running trailblazer scan command
-    cli_runner.invoke(scan, [])
-
-    # THEN the status of analysis should be updated from pending
-    analysis = analysis_store.get_latest_analysis_for_case(ongoing_analysis_case_id)
-    assert analysis.status == TrailblazerStatus.RUNNING
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -483,11 +483,13 @@ def test_scan(
     mocker,
     ongoing_analysis_case_id: str,
     slurm_squeue_output: dict[str, str],
+    slurm_job_ids: list[int]
 ):
     """Test scanning for analyses and updating analysis status."""
     caplog.set_level("INFO")
 
     # GIVEN SLURM squeue output for an analysis
+    mocker.patch("trailblazer.services.job_service.job_service.get_slurm_job_ids", return_value=slurm_job_ids)
     mocker.patch(
         FUNC_GET_SLURM_SQUEUE_OUTPUT_PATH,
         return_value=subprocess.check_output(
@@ -499,9 +501,6 @@ def test_scan(
 
     # WHEN running trailblazer scan command
     cli_runner.invoke(scan, [])
-
-    # THEN log that analyses are updated
-    assert "All analyses updated" in caplog.text
 
     # THEN the status of analysis should be updated from pending
     analysis = analysis_store.get_latest_analysis_for_case(ongoing_analysis_case_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,7 +338,9 @@ def slurm_job_ids() -> list[int]:
 
 
 @pytest.fixture(scope="session")
-def slurm_queue() -> SQueue
+def slurm_queue():
+    pass
+
 
 @pytest.fixture(scope="session")
 def tower_case_config() -> dict[str, dict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,6 +332,14 @@ def slurm_squeue_output(squeue_dir: Path) -> dict[str, str]:
     }
 
 
+@pytest.fixture
+def slurm_job_ids() -> list[int]:
+    return [690993, 690994, 690992, 690988, 690989, 690990]
+
+
+@pytest.fixture(scope="session")
+def slurm_queue() -> SQueue
+
 @pytest.fixture(scope="session")
 def tower_case_config() -> dict[str, dict]:
     """Return a Tower case configs."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,11 +338,6 @@ def slurm_job_ids() -> list[int]:
 
 
 @pytest.fixture(scope="session")
-def slurm_queue():
-    pass
-
-
-@pytest.fixture(scope="session")
 def tower_case_config() -> dict[str, dict]:
     """Return a Tower case configs."""
     return {

--- a/tests/integration/services/test_job_service.py
+++ b/tests/integration/services/test_job_service.py
@@ -12,7 +12,7 @@ def test_update_upload_jobs(
 
     # GIVEN that slurm says the upload job is completed
     slurm_service_mock = mock.Mock()
-    slurm_service_mock.get_job_info.return_value = upload_job_info
+    slurm_service_mock.get_job.return_value = upload_job_info
     job_service.slurm_service = slurm_service_mock
 
     # WHEN updating the upload jobs

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -3,12 +3,37 @@ import pytest
 
 from trailblazer.services.analysis_service.analysis_service import AnalysisService
 from trailblazer.services.job_service.job_service import JobService
+from trailblazer.services.slurm.dtos import SlurmJobInfo
+from trailblazer.services.slurm.slurm_cli_service.slurm_cli_service import SlurmCLIService
+from trailblazer.services.slurm.slurm_service import SlurmService
 from trailblazer.store.store import Store
 
 
 @pytest.fixture
-def job_service(store: Store) -> JobService:
-    return JobService(store=store, slurm_service=Mock())
+def slurm_completed_job_info() -> SlurmJobInfo:
+    return SlurmJobInfo(
+        slurm_id=690994,
+        name="job",
+        status="completed",
+        elapsed=1000,
+        started_at="2020-10-22T11:43:33",
+    )
+
+
+@pytest.fixture
+def slurm_service(slurm_completed_job_info) -> SlurmService:
+    """Slurm service reporting all jobs as completed."""
+    service = SlurmCLIService(client=Mock())
+    service.get_job_info = Mock(return_value=slurm_completed_job_info)
+    return service
+
+
+@pytest.fixture
+def job_service(store: Store, slurm_service: SlurmService, slurm_job_ids, mocker) -> JobService:
+    mocker.patch(
+        "trailblazer.services.job_service.job_service.get_slurm_job_ids", return_value=slurm_job_ids
+    )
+    return JobService(store=store, slurm_service=slurm_service)
 
 
 @pytest.fixture

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,9 +1,16 @@
+from unittest.mock import Mock
 import pytest
 
 from trailblazer.services.analysis_service.analysis_service import AnalysisService
+from trailblazer.services.job_service.job_service import JobService
 from trailblazer.store.store import Store
 
 
 @pytest.fixture
-def analysis_service(analysis_store: Store) -> AnalysisService:
-    return AnalysisService(analysis_store)
+def job_service(store: Store) -> JobService:
+    return JobService(store=store, slurm_service=Mock())
+
+
+@pytest.fixture
+def analysis_service(analysis_store: Store, job_service: JobService) -> AnalysisService:
+    return AnalysisService(store=analysis_store, job_service=job_service)

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -24,7 +24,8 @@ def slurm_completed_job_info() -> SlurmJobInfo:
 def slurm_service(slurm_completed_job_info) -> SlurmService:
     """Slurm service reporting all jobs as completed."""
     service = SlurmCLIService(client=Mock())
-    service.get_job_info = Mock(return_value=slurm_completed_job_info)
+    service.get_job = Mock(return_value=slurm_completed_job_info)
+    service.get_jobs = Mock(return_value=[slurm_completed_job_info])
     return service
 
 

--- a/tests/services/test_analysis_service.py
+++ b/tests/services/test_analysis_service.py
@@ -1,3 +1,4 @@
+from trailblazer.constants import TrailblazerStatus
 from trailblazer.dto.update_analyses import AnalysisUpdate, UpdateAnalyses
 from trailblazer.services.analysis_service.analysis_service import AnalysisService
 from trailblazer.store.models import Analysis, User
@@ -15,3 +16,15 @@ def test_patch_analyses_delivered(
     analysis_service.update_analyses(data=update_analyses, user=user)
 
     assert analysis.delivered_by
+
+
+def test_update_analysis_status(analysis_store: Store, analysis_service: AnalysisService):
+    # GIVEN a store with ongoing analyses
+    assert analysis_store.get_ongoing_analyses()
+    # GIVEN that all slurm jobs are completed
+
+    # WHEN updating the status of the analyses
+    analysis_service.update_ongoing_analyses()
+
+    # THEN the status of all analyses should be updated
+    assert not analysis_store.get_ongoing_analyses()

--- a/tests/store/crud/test_delete.py
+++ b/tests/store/crud/test_delete.py
@@ -29,7 +29,7 @@ def test_delete_analysis(analysis_store: MockStore, case_id: str):
     """Test analysis is successfully deleted."""
 
     # GIVEN a not ongoing analysis
-    analysis_store.update_analysis_status(case_id=case_id, status=TrailblazerStatus.CANCELLED)
+    analysis_store.update_analysis_status_by_case_id(case_id=case_id, status=TrailblazerStatus.CANCELLED)
     analysis: Analysis | None = analysis_store.get_latest_analysis_for_case(case_id=case_id)
 
     # WHEN deleting analysis

--- a/tests/store/crud/test_delete.py
+++ b/tests/store/crud/test_delete.py
@@ -29,7 +29,9 @@ def test_delete_analysis(analysis_store: MockStore, case_id: str):
     """Test analysis is successfully deleted."""
 
     # GIVEN a not ongoing analysis
-    analysis_store.update_analysis_status_by_case_id(case_id=case_id, status=TrailblazerStatus.CANCELLED)
+    analysis_store.update_analysis_status_by_case_id(
+        case_id=case_id, status=TrailblazerStatus.CANCELLED
+    )
     analysis: Analysis | None = analysis_store.get_latest_analysis_for_case(case_id=case_id)
 
     # WHEN deleting analysis

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -291,7 +291,7 @@ def test_update_analysis_status_with_failed(analysis_store: MockStore, case_id: 
     assert analysis.status != TrailblazerStatus.FAILED
 
     # WHEN setting analysis to failed
-    analysis_store.update_analysis_status(case_id=analysis.case_id, status=TrailblazerStatus.FAILED)
+    analysis_store.update_analysis_status_by_case_id(case_id=analysis.case_id, status=TrailblazerStatus.FAILED)
 
     # THEN the analysis status should be updated to failed
     assert analysis.status == TrailblazerStatus.FAILED

--- a/tests/store/crud/test_update.py
+++ b/tests/store/crud/test_update.py
@@ -291,7 +291,9 @@ def test_update_analysis_status_with_failed(analysis_store: MockStore, case_id: 
     assert analysis.status != TrailblazerStatus.FAILED
 
     # WHEN setting analysis to failed
-    analysis_store.update_analysis_status_by_case_id(case_id=analysis.case_id, status=TrailblazerStatus.FAILED)
+    analysis_store.update_analysis_status_by_case_id(
+        case_id=analysis.case_id, status=TrailblazerStatus.FAILED
+    )
 
     # THEN the analysis status should be updated to failed
     assert analysis.status == TrailblazerStatus.FAILED

--- a/trailblazer/apps/slurm/api.py
+++ b/trailblazer/apps/slurm/api.py
@@ -30,7 +30,7 @@ def cancel_slurm_job(slurm_id: int, analysis_host: str | None = None) -> None:
     subprocess.Popen(scancel_commands)
 
 
-def _get_slurm_queue(job_ids: str, analysis_host: str | None = None) -> SqueueResult:
+def get_slurm_queue(job_ids: str, analysis_host: str | None = None) -> SqueueResult:
     """Return squeue output from ongoing analyses in SLURM."""
     queue_output: str = get_slurm_queue_output(job_ids=job_ids, analysis_host=analysis_host)
     return get_squeue_result(queue_output)

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -232,7 +232,7 @@ def set_analysis_status(
     """Set the status of the latest analysis for a given case id."""
     trailblazer_db: Store = context.obj["trailblazer_db"]
     try:
-        trailblazer_db.update_analysis_status(case_id=case_id, status=status)
+        trailblazer_db.update_analysis_status_by_case_id(case_id=case_id, status=status)
     except ValueError as error:
         LOG.error(error)
         raise click.Abort from error

--- a/trailblazer/clients/slurm_cli_client/slurm_cli_client.py
+++ b/trailblazer/clients/slurm_cli_client/slurm_cli_client.py
@@ -1,4 +1,4 @@
-from trailblazer.apps.slurm.api import _get_slurm_queue
+from trailblazer.apps.slurm.api import get_slurm_queue
 from trailblazer.apps.slurm.models import SqueueResult
 
 
@@ -7,4 +7,4 @@ class SlurmCLIClient:
         self.host = host
 
     def get_slurm_queue(self, job_ids: str) -> SqueueResult:
-        return _get_slurm_queue(job_ids=job_ids, analysis_host=self.host)
+        return get_slurm_queue(job_ids=job_ids, analysis_host=self.host)

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -73,6 +73,10 @@ class SlurmJobStatus(StrEnum):
     def ongoing_statuses(cls) -> tuple:
         return cls.PENDING, cls.RUNNING, cls.COMPLETING
 
+    @classmethod
+    def fail_statuses(cls) -> tuple:
+        return cls.FAILED, cls.TIME_OUT
+
 
 class CharacterFormat(StrEnum):
     """Define character encoding/decoding to use."""
@@ -120,6 +124,10 @@ class TrailblazerStatus(StrEnum):
     @classmethod
     def ongoing_statuses(cls) -> tuple[str, str, str, str]:
         return cls.PENDING, cls.RUNNING, cls.COMPLETING, cls.ERROR
+
+    @classmethod
+    def fail_statuses(cls) -> tuple[str, str, str, str]:
+        return cls.ERROR, cls.FAILED
 
 
 class TrailblazerStatusColor(StrEnum):

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -126,10 +126,6 @@ class TrailblazerStatus(StrEnum):
     def ongoing_statuses(cls) -> tuple[str, str, str, str]:
         return cls.PENDING, cls.RUNNING, cls.COMPLETING, cls.ERROR
 
-    @classmethod
-    def fail_statuses(cls) -> tuple[str, str, str, str]:
-        return cls.ERROR, cls.FAILED
-
 
 class TrailblazerStatusColor(StrEnum):
     """Trailblazer status colors."""

--- a/trailblazer/containers.py
+++ b/trailblazer/containers.py
@@ -36,7 +36,7 @@ class Container(containers.DeclarativeContainer):
     slurm_service = providers.Singleton(SlurmCLIService, client=slurm_client)
 
     job_service = providers.Factory(JobService, store=store, slurm_service=slurm_service)
-    analysis_service = providers.Factory(AnalysisService, store=store)
+    analysis_service = providers.Factory(AnalysisService, store=store, job_service=job_service)
 
     encryption_service = providers.Singleton(EncryptionService, secret_key=encryption_key)
 

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -239,7 +239,7 @@ def set_analysis_status():
     try:
         case_id: str = put_request.get("case_id")
         status: str = put_request.get("status")
-        store.update_analysis_status(case_id=case_id, status=status)
+        store.update_analysis_status_by_case_id(case_id=case_id, status=status)
         return (
             jsonify(f"Success! Analysis set to {put_request.get('status')} request sent"),
             HTTPStatus.CREATED,

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -1,3 +1,4 @@
+from trailblazer.constants import TrailblazerStatus
 from trailblazer.dto import (
     AnalysesRequest,
     AnalysesResponse,
@@ -69,10 +70,16 @@ class AnalysisService:
         return AnalysesResponse(analyses=response_data, total_count=total_count)
 
     def update_ongoing_analyses(self) -> None:
+        self.store.update_ongoing_analyses()
+
+    def update_analysis_status(self) -> None:
         analyses: list[Analysis] = self.store.get_ongoing_analyses()
         for analysis in analyses:
             self.job_service.update_analysis_jobs(analysis.id)
-        self.store.update_ongoing_analyses()
+            status: TrailblazerStatus = self.job_service.get_analysis_status(analysis.id)
+            self.store.update_analysis_status(analysis_id=analysis.id, status=status)
+            progression: float = self.job_service.get_analysis_progression(analysis.id)
+            self.store.update_analysis_progress(analysis_id=analysis.id, progression=progression)
 
     def get_summaries(self, request_data: SummariesRequest) -> SummariesResponse:
         summaries: list[Summary] = []

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -15,13 +15,15 @@ from trailblazer.services.analysis_service.utils import (
     create_summary,
     create_update_analyses_response,
 )
+from trailblazer.services.job_service.job_service import JobService
 from trailblazer.store.models import Analysis, Job, User
 from trailblazer.store.store import Store
 
 
 class AnalysisService:
-    def __init__(self, store: Store):
+    def __init__(self, store: Store, job_service: JobService):
         self.store = store
+        self.job_service = job_service
 
     def get_analyses(self, request: AnalysesRequest) -> AnalysesResponse:
         analyses, total_count = self.store.get_paginated_analyses(request)
@@ -67,6 +69,9 @@ class AnalysisService:
         return AnalysesResponse(analyses=response_data, total_count=total_count)
 
     def update_ongoing_analyses(self) -> None:
+        analyses: list[Analysis] = self.store.get_ongoing_analyses()
+        for analysis in analyses:
+            self.job_service.update_analysis_jobs(analysis.id)
         self.store.update_ongoing_analyses()
 
     def get_summaries(self, request_data: SummariesRequest) -> SummariesResponse:

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -72,14 +72,14 @@ class AnalysisService:
     def update_ongoing_analyses(self) -> None:
         self.store.update_ongoing_analyses()
 
-    def update_analysis_status(self) -> None:
+    def update_analyses_status(self) -> None:
         analyses: list[Analysis] = self.store.get_ongoing_analyses()
         for analysis in analyses:
             self.job_service.update_analysis_jobs(analysis.id)
             status: TrailblazerStatus = self.job_service.get_analysis_status(analysis.id)
+            progress: float = self.job_service.get_analysis_progression(analysis.id)
+            self.store.update_analysis_progress(analysis_id=analysis.id, progress=progress)
             self.store.update_analysis_status(analysis_id=analysis.id, status=status)
-            progression: float = self.job_service.get_analysis_progression(analysis.id)
-            self.store.update_analysis_progress(analysis_id=analysis.id, progression=progression)
 
     def get_summaries(self, request_data: SummariesRequest) -> SummariesResponse:
         summaries: list[Summary] = []

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -70,12 +70,9 @@ class AnalysisService:
         return AnalysesResponse(analyses=response_data, total_count=total_count)
 
     def update_ongoing_analyses(self) -> None:
-        self.store.update_ongoing_analyses()
-
-    def update_analyses_status(self) -> None:
         analyses: list[Analysis] = self.store.get_ongoing_analyses()
         for analysis in analyses:
-            self.job_service.update_analysis_jobs(analysis.id)
+            self.job_service.update_jobs(analysis.id)
             status: TrailblazerStatus = self.job_service.get_analysis_status(analysis.id)
             progress: float = self.job_service.get_analysis_progression(analysis.id)
             self.store.update_analysis_progress(analysis_id=analysis.id, progress=progress)

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -44,7 +44,7 @@ class JobService:
         if analysis.workflow_manager == WorkflowManager.SLURM:
             self._update_slurm_jobs(analysis_id)
         if analysis.workflow_manager == WorkflowManager.TOWER:
-            self.store._update_analysis_from_tower_output(analysis_id)
+            self.store.update_tower_run_status(analysis_id)
 
     def _update_slurm_jobs(self, analysis_id: int) -> None:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -36,7 +36,7 @@ class JobService:
         jobs: list[Job] = self.store.get_ongoing_upload_jobs()
         for job in jobs:
             LOG.info(f"Updating upload job {job.id}")
-            updated_job: SlurmJobInfo = self.slurm_service.get_job_info(job.slurm_id)
+            updated_job: SlurmJobInfo = self.slurm_service.get_job(job.slurm_id)
             self.store.update_job(job_id=job.id, job_info=updated_job)
 
     def update_jobs(self, analysis_id: int) -> None:
@@ -52,11 +52,8 @@ class JobService:
     def _update_slurm_jobs(self, analysis_id: int) -> None:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
         slurm_ids: list[int] = get_slurm_job_ids(analysis.config_path)
-        jobs: list[Job] = []
-        for slurm_id in slurm_ids:
-            job_info: SlurmJobInfo = self.slurm_service.get_job_info(slurm_id)
-            job: Job = slurm_info_to_job(job_info)
-            jobs.append(job)
+        slurm_jobs: list[SlurmJobInfo] = self.slurm_service.get_jobs(slurm_ids)
+        jobs: list[Job] = [slurm_info_to_job(job_info) for job_info in slurm_jobs]
         self.store.replace_jobs(analysis_id=analysis_id, jobs=jobs)
 
     def get_analysis_status(self, analysis_id: int) -> TrailblazerStatus:

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -1,11 +1,17 @@
 from datetime import datetime
 import logging
+from pathlib import Path
 
 from trailblazer.dto import CreateJobRequest, FailedJobsRequest, FailedJobsResponse, JobResponse
-from trailblazer.services.job_service.utils import create_failed_jobs_response, create_job_response
+from trailblazer.services.job_service.mappers import (
+    create_failed_jobs_response,
+    create_job_response,
+    slurm_info_to_job,
+)
+from trailblazer.services.job_service.utils import get_slurm_job_ids
 from trailblazer.services.slurm.dtos import SlurmJobInfo
 from trailblazer.services.slurm.slurm_service import SlurmService
-from trailblazer.store.models import Job
+from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
 from trailblazer.utils.datetime import get_date_number_of_days_ago
 
@@ -32,3 +38,16 @@ class JobService:
             LOG.info(f"Updating upload job {job.id}")
             updated_job: SlurmJobInfo = self.slurm_service.get_job_info(job.slurm_id)
             self.store.update_job(job_id=job.id, job_info=updated_job)
+
+    def update_analysis_jobs(self, analysis_id: int) -> None:
+        analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
+        slurm_ids: list[int] = get_slurm_job_ids(analysis.config_path)
+        jobs: list[Job] = []
+        for slurm_id in slurm_ids:
+            job_info: SlurmJobInfo = self.slurm_service.get_job_info(slurm_id)
+            job: Job = slurm_info_to_job(job_info)
+            jobs.append(job)
+        self.store.add_jobs(analysis_id=analysis_id, jobs=jobs)
+
+    def get_analysis_status(self, analysis_id: int) -> None:
+        pass

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -8,7 +8,7 @@ from trailblazer.services.job_service.mappers import (
     create_job_response,
     slurm_info_to_job,
 )
-from trailblazer.services.job_service.utils import get_progression, get_slurm_job_ids, get_status
+from trailblazer.services.job_service.utils import get_progress, get_slurm_job_ids, get_status
 from trailblazer.services.slurm.dtos import SlurmJobInfo
 from trailblazer.services.slurm.slurm_service import SlurmService
 from trailblazer.store.models import Analysis, Job
@@ -41,14 +41,13 @@ class JobService:
 
     def update_analysis_jobs(self, analysis_id: int) -> None:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
-        self.store.delete_analysis_jobs(analysis_id)
         slurm_ids: list[int] = get_slurm_job_ids(analysis.config_path)
         jobs: list[Job] = []
         for slurm_id in slurm_ids:
             job_info: SlurmJobInfo = self.slurm_service.get_job_info(slurm_id)
             job: Job = slurm_info_to_job(job_info)
             jobs.append(job)
-        self.store.add_jobs(analysis_id=analysis_id, jobs=jobs)
+        self.store.replace_jobs(analysis_id=analysis_id, jobs=jobs)
 
     def get_analysis_status(self, analysis_id: int) -> TrailblazerStatus:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
@@ -56,4 +55,4 @@ class JobService:
 
     def get_analysis_progression(self, analysis_id: int) -> float:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
-        return get_progression(analysis.jobs)
+        return get_progress(analysis.jobs)

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -42,6 +42,8 @@ class JobService:
     def update_jobs(self, analysis_id: int) -> None:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
         try:
+            if analysis.case_id == "blazinginsect":
+                self._update_slurm_jobs(analysis_id)
             if analysis.workflow_manager == WorkflowManager.SLURM:
                 self._update_slurm_jobs(analysis_id)
             if analysis.workflow_manager == WorkflowManager.TOWER:

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -42,8 +42,6 @@ class JobService:
     def update_jobs(self, analysis_id: int) -> None:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
         try:
-            if analysis.case_id == "blazinginsect":
-                self._update_slurm_jobs(analysis_id)
             if analysis.workflow_manager == WorkflowManager.SLURM:
                 self._update_slurm_jobs(analysis_id)
             if analysis.workflow_manager == WorkflowManager.TOWER:

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -41,10 +41,13 @@ class JobService:
 
     def update_jobs(self, analysis_id: int) -> None:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
-        if analysis.workflow_manager == WorkflowManager.SLURM:
-            self._update_slurm_jobs(analysis_id)
-        if analysis.workflow_manager == WorkflowManager.TOWER:
-            self.store.update_tower_run_status(analysis_id)
+        try:
+            if analysis.workflow_manager == WorkflowManager.SLURM:
+                self._update_slurm_jobs(analysis_id)
+            if analysis.workflow_manager == WorkflowManager.TOWER:
+                self.store.update_tower_run_status(analysis_id)
+        except Exception as error:
+            LOG.error(f"Failed to update jobs {analysis.case_id} - {analysis.id}: {error}")
 
     def _update_slurm_jobs(self, analysis_id: int) -> None:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)

--- a/trailblazer/services/job_service/mappers.py
+++ b/trailblazer/services/job_service/mappers.py
@@ -1,0 +1,21 @@
+from trailblazer.dto.failed_jobs_response import FailedJobsResponse
+from trailblazer.dto.job_response import JobResponse
+from trailblazer.services.slurm.dtos import SlurmJobInfo
+from trailblazer.store.models import Job
+
+
+def create_job_response(job: Job) -> JobResponse:
+    return JobResponse(
+        slurm_id=job.slurm_id, analysis_id=job.analysis_id, status=job.status, id=job.id
+    )
+
+
+def create_failed_jobs_response(failed_job_statistics: list[dict]) -> FailedJobsResponse:
+    return FailedJobsResponse(jobs=failed_job_statistics)
+
+
+def slurm_info_to_job(slurm_job_info: SlurmJobInfo) -> Job:
+    return Job(
+        slurm_id=slurm_job_info.slurm_id,
+        name=slurm_job_info.name,
+    )

--- a/trailblazer/services/job_service/mappers.py
+++ b/trailblazer/services/job_service/mappers.py
@@ -18,4 +18,7 @@ def slurm_info_to_job(slurm_job_info: SlurmJobInfo) -> Job:
     return Job(
         slurm_id=slurm_job_info.slurm_id,
         name=slurm_job_info.name,
+        status=slurm_job_info.status,
+        elapsed=slurm_job_info.elapsed,
+        started_at=slurm_job_info.started_at,
     )

--- a/trailblazer/services/job_service/utils.py
+++ b/trailblazer/services/job_service/utils.py
@@ -1,13 +1,23 @@
 from pathlib import Path
-from trailblazer.constants import FileFormat
+from trailblazer.constants import FileFormat, TrailblazerStatus
 from trailblazer.io.controller import ReadFile
+from trailblazer.store.models import Job
 
 
-def get_slurm_job_ids(job_id_file: Path) -> list[int]:
+def get_slurm_job_ids(job_id_file: str) -> list[int]:
+    job_id_file_path = Path(job_id_file)
     content: dict = ReadFile.get_content_from_file(
-        file_format=FileFormat.YAML, file_path=job_id_file
+        file_format=FileFormat.YAML, file_path=job_id_file_path
     )
     job_ids: list[int] = []
     for row in content.values():
         [job_ids.append(job_id) for job_id in row]
     return job_ids
+
+
+def get_status(jobs: list[Job]) -> TrailblazerStatus:
+    pass
+
+
+def get_progression(jobs: list[Job]) -> float:
+    pass

--- a/trailblazer/services/job_service/utils.py
+++ b/trailblazer/services/job_service/utils.py
@@ -1,13 +1,13 @@
-from trailblazer.dto.failed_jobs_response import FailedJobsResponse
-from trailblazer.dto.job_response import JobResponse
-from trailblazer.store.models import Job
+from pathlib import Path
+from trailblazer.constants import FileFormat
+from trailblazer.io.controller import ReadFile
 
 
-def create_job_response(job: Job) -> JobResponse:
-    return JobResponse(
-        slurm_id=job.slurm_id, analysis_id=job.analysis_id, status=job.status, id=job.id
+def get_slurm_job_ids(job_id_file: Path) -> list[int]:
+    content: dict = ReadFile.get_content_from_file(
+        file_format=FileFormat.YAML, file_path=job_id_file
     )
-
-
-def create_failed_jobs_response(failed_job_statistics: list[dict]) -> FailedJobsResponse:
-    return FailedJobsResponse(jobs=failed_job_statistics)
+    job_ids: list[int] = []
+    for row in content.values():
+        [job_ids.append(job_id) for job_id in row]
+    return job_ids

--- a/trailblazer/services/job_service/utils.py
+++ b/trailblazer/services/job_service/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from trailblazer.constants import FileFormat, TrailblazerStatus
+from trailblazer.constants import FileFormat, SlurmJobStatus, TrailblazerStatus
 from trailblazer.io.controller import ReadFile
 from trailblazer.store.models import Job
 
@@ -16,8 +16,30 @@ def get_slurm_job_ids(job_id_file: str) -> list[int]:
 
 
 def get_status(jobs: list[Job]) -> TrailblazerStatus:
-    pass
+    is_running: bool = has_running_jobs(jobs)
+    is_failed: bool = has_failed_jobs(jobs)
+    if is_failed and is_running:
+        return TrailblazerStatus.ERROR
+    if is_failed:
+        return TrailblazerStatus.FAILED
+    if is_running:
+        return TrailblazerStatus.RUNNING
+    return TrailblazerStatus.CANCELLED
 
 
-def get_progression(jobs: list[Job]) -> float:
-    pass
+def has_running_jobs(jobs: list[Job]) -> bool:
+    run_statuses = SlurmJobStatus.ongoing_statuses()
+    return any(job.status in run_statuses for job in jobs)
+
+
+def has_failed_jobs(jobs: list[Job]) -> bool:
+    fail_statuses = SlurmJobStatus.fail_statuses()
+    return any(job.status in fail_statuses for job in jobs)
+
+
+def get_progress(jobs: list[Job]) -> float:
+    total_jobs: int = len(jobs)
+    if total_jobs == 0:
+        return 0.0
+    completed_jobs: int = len([job for job in jobs if job.status == SlurmJobStatus.COMPLETED])
+    return completed_jobs / total_jobs

--- a/trailblazer/services/slurm/slurm_cli_service/slurm_cli_service.py
+++ b/trailblazer/services/slurm/slurm_cli_service/slurm_cli_service.py
@@ -9,7 +9,11 @@ class SlurmCLIService(SlurmService):
     def __init__(self, client: SlurmCLIClient):
         self.client = client
 
-    def get_job_info(self, job_id: int) -> SlurmJobInfo:
+    def get_job(self, job_id: int) -> SlurmJobInfo:
         queue: SqueueResult = self.client.get_slurm_queue(str(job_id))
         job: SqueueJob = queue.jobs[0]
         return create_job_info_dto(job)
+
+    def get_jobs(self, job_ids: list[int]) -> list[SlurmJobInfo]:
+        queue: SqueueResult = self.client.get_slurm_queue(*map(str, job_ids))
+        return [create_job_info_dto(job) for job in queue.jobs]

--- a/trailblazer/services/slurm/slurm_service.py
+++ b/trailblazer/services/slurm/slurm_service.py
@@ -5,5 +5,9 @@ from trailblazer.services.slurm.dtos import SlurmJobInfo
 
 class SlurmService(ABC):
     @abstractmethod
-    def get_job_info(self, job_id: int) -> SlurmJobInfo:
+    def get_job(self, job_id: int) -> SlurmJobInfo:
+        pass
+
+    @abstractmethod
+    def get_jobs(self, job_ids: list[int]) -> list[SlurmJobInfo]:
         pass

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -59,8 +59,8 @@ class CreateHandler(BaseHandler):
         session.commit()
         return job
 
-    def add_jobs(self, analysis_id: int, jobs: list[Job]):
-        """Add a list of jobs to the database."""
+    def replace_jobs(self, analysis_id: int, jobs: list[Job]):
+        self.delete_analysis_jobs(analysis_id)
         analysis: Analysis = self.get_analysis_with_id(analysis_id)
         for job in jobs:
             analysis.jobs.append(job)

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -58,3 +58,11 @@ class CreateHandler(BaseHandler):
         session: Session = get_session()
         session.commit()
         return job
+
+    def add_jobs(self, analysis_id: int, jobs: list[Job]):
+        """Add a list of jobs to the database."""
+        analysis: Analysis = self.get_analysis_with_id(analysis_id)
+        for job in jobs:
+            analysis.jobs.append(job)
+        session: Session = get_session()
+        session.commit()

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -60,8 +60,8 @@ class CreateHandler(BaseHandler):
         return job
 
     def replace_jobs(self, analysis_id: int, jobs: list[Job]):
-        self.delete_analysis_jobs(analysis_id)
         analysis: Analysis = self.get_analysis_with_id(analysis_id)
+        self.delete_analysis_jobs(analysis)
         for job in jobs:
             analysis.jobs.append(job)
         session: Session = get_session()

--- a/trailblazer/store/crud/delete.py
+++ b/trailblazer/store/crud/delete.py
@@ -14,10 +14,9 @@ LOG = logging.getLogger(__name__)
 class DeleteHandler(BaseHandler):
     """Class for deleting items in the database."""
 
-    def delete_analysis_jobs(self, analysis_id: int) -> None:
+    def delete_analysis_jobs(self, analysis: Analysis) -> None:
         """Delete all jobs linked to the given analysis."""
         session: Session = get_session()
-        analysis: Analysis | None = self.get_analysis_with_id(analysis_id)
         for job in analysis.jobs:
             if job.job_type == JobType.ANALYSIS:
                 session.delete(job)

--- a/trailblazer/store/crud/delete.py
+++ b/trailblazer/store/crud/delete.py
@@ -14,9 +14,10 @@ LOG = logging.getLogger(__name__)
 class DeleteHandler(BaseHandler):
     """Class for deleting items in the database."""
 
-    def delete_analysis_jobs(self, analysis: Analysis) -> None:
+    def delete_analysis_jobs(self, analysis_id: int) -> None:
         """Delete all jobs linked to the given analysis."""
         session: Session = get_session()
+        analysis: Analysis | None = self.get_analysis_with_id(analysis_id)
         for job in analysis.jobs:
             if job.job_type == JobType.ANALYSIS:
                 session.delete(job)

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -74,7 +74,7 @@ class UpdateHandler(BaseHandler):
         """Update analysis jobs from supplied squeue results."""
         if len(squeue_result.jobs) == 0:
             return
-        self.delete_analysis_jobs(analysis)
+        self.delete_analysis_jobs(analysis.id)
 
         session: Session = get_session()
         for job in squeue_result.jobs:
@@ -137,7 +137,7 @@ class UpdateHandler(BaseHandler):
         analysis.status = tower_api.status
         analysis.progress = tower_api.progress
         analysis.logged_at = datetime.now()
-        self.delete_analysis_jobs(analysis)
+        self.delete_analysis_jobs(analysis.id)
         jobs: list[dict] = tower_api.get_jobs(analysis.id)
         self.update_jobs(jobs)
         session: Session = get_session()

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -201,7 +201,7 @@ class UpdateHandler(BaseHandler):
         )
         tower_api.cancel()
 
-    def update_analysis_status(self, case_id: str, status: str):
+    def update_analysis_status_by_case_id(self, case_id: str, status: str):
         """Setting analysis status."""
         status: str = status.lower()
         if status not in set(TrailblazerStatus.statuses()):
@@ -215,7 +215,9 @@ class UpdateHandler(BaseHandler):
     def update_analysis_status_to_completed(self, analysis_id: int) -> None:
         """Set an analysis status to 'completed'."""
         analysis: Analysis | None = self.get_analysis_with_id(analysis_id)
-        self.update_analysis_status(case_id=analysis.case_id, status=TrailblazerStatus.COMPLETED)
+        self.update_analysis_status_by_case_id(
+            case_id=analysis.case_id, status=TrailblazerStatus.COMPLETED
+        )
 
     def update_analysis_uploaded_at(self, case_id: str, uploaded_at: datetime) -> None:
         """Set analysis uploaded at for an analysis."""
@@ -313,5 +315,17 @@ class UpdateHandler(BaseHandler):
     def update_user_token(self, refresh_token: str, user_id: int) -> None:
         user: User | None = self.get_user_by_id(user_id)
         user.refresh_token = refresh_token
+        session: Session = get_session()
+        session.commit()
+
+    def update_analysis_status(self, analysis_id: int, status: TrailblazerStatus) -> None:
+        analysis: Analysis | None = self.get_analysis_with_id(analysis_id)
+        analysis.status = status
+        session: Session = get_session()
+        session.commit()
+
+    def update_analysis_progress(self, analysis_id: int, progression: float) -> None:
+        analysis: Analysis | None = self.get_analysis_with_id(analysis_id)
+        analysis.progress = progression
         session: Session = get_session()
         session.commit()

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -324,8 +324,8 @@ class UpdateHandler(BaseHandler):
         session: Session = get_session()
         session.commit()
 
-    def update_analysis_progress(self, analysis_id: int, progression: float) -> None:
+    def update_analysis_progress(self, analysis_id: int, progress: float) -> None:
         analysis: Analysis | None = self.get_analysis_with_id(analysis_id)
-        analysis.progress = progression
+        analysis.progress = progress
         session: Session = get_session()
         session.commit()

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -323,6 +323,7 @@ class UpdateHandler(BaseHandler):
         analysis.status = status
         session: Session = get_session()
         session.commit()
+        LOG.info(f"Updated status {analysis.case_id} - {analysis.id}: {analysis.status} ")
 
     def update_analysis_progress(self, analysis_id: int, progress: float) -> None:
         analysis: Analysis | None = self.get_analysis_with_id(analysis_id)

--- a/trailblazer/store/crud/update.py
+++ b/trailblazer/store/crud/update.py
@@ -74,7 +74,7 @@ class UpdateHandler(BaseHandler):
         """Update analysis jobs from supplied squeue results."""
         if len(squeue_result.jobs) == 0:
             return
-        self.delete_analysis_jobs(analysis.id)
+        self.delete_analysis_jobs(analysis)
 
         session: Session = get_session()
         for job in squeue_result.jobs:
@@ -137,7 +137,7 @@ class UpdateHandler(BaseHandler):
         analysis.status = tower_api.status
         analysis.progress = tower_api.progress
         analysis.logged_at = datetime.now()
-        self.delete_analysis_jobs(analysis.id)
+        self.delete_analysis_jobs(analysis)
         jobs: list[dict] = tower_api.get_jobs(analysis.id)
         self.update_jobs(jobs)
         session: Session = get_session()


### PR DESCRIPTION
## Description
Refactor logic for updating analyses with information from slurm. The logic does not belong in the data access layer.

New design
- Analysis service: uses a job service to update the analysis (status, progress etc.).
- Job service: uses a slurm service to retrieve information about jobs from slurm.
- Slurm service: defines an interface for retrieving information about jobs from slurm.
- Slurm CLI service: implements the slurm service interface, uses a Slurm CLI client.
- Slurm CLI client: retrieves information from slurm via the CLI (wraps the old logic).

I'll remove all the deprecated logic in a separate PR.

### Fixed
- Extract logic for parsing slurm from data access layer
- Abstract away slurm interactions to enable going via API or CLI

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
