### PR TITLE
(Streamline delivery) Report completed/delivered correctly

### DIFF
--- a/trailblazer/dto/summaries_response.py
+++ b/trailblazer/dto/summaries_response.py
@@ -4,10 +4,12 @@ from pydantic import BaseModel
 class Summary(BaseModel):
     order_id: int
     total: int
-    delivered: int
-    running: int
+
     cancelled: int
+    completed: int
+    delivered: int
     failed: int
+    running: int
 
 
 class SummariesResponse(BaseModel):

--- a/trailblazer/services/analysis_service/utils.py
+++ b/trailblazer/services/analysis_service/utils.py
@@ -9,9 +9,15 @@ def get_status_count(analyses: list[Analysis], status: TrailblazerStatus) -> int
     return len([a for a in analyses if a.status == status])
 
 
+def get_delivered_count(analyses: list[Analysis]) -> int:
+    return len([analysis for analysis in analyses if analysis.delivery])
+
+
 def create_summary(analyses: list[Analysis], order_id: int) -> Summary:
     total: int = len(analyses)
-    delivered: int = get_status_count(analyses=analyses, status=TrailblazerStatus.COMPLETED)
+    completed: int = get_status_count(analyses=analyses, status=TrailblazerStatus.COMPLETED)
+    delivered: int = get_delivered_count(analyses)
+    completed -= delivered
     running: int = get_status_count(analyses=analyses, status=TrailblazerStatus.RUNNING)
     cancelled: int = get_status_count(analyses=analyses, status=TrailblazerStatus.CANCELLED)
     failed = get_status_count(analyses=analyses, status=TrailblazerStatus.FAILED)
@@ -22,6 +28,7 @@ def create_summary(analyses: list[Analysis], order_id: int) -> Summary:
         running=running,
         cancelled=cancelled,
         failed=failed,
+        completed=completed,
     )
 
 


### PR DESCRIPTION
## Description

Currently analyses with "completed" status are reported as "delivered" in the summary. This PR creates a distinction between delivered and completed analyses.

### Changed

- Delivered analyses count as delivered and completed analyses count as completed in the summary response.

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
