### PR TITLE
(Streamline delivery) Report correct counts

### DIFF
--- a/trailblazer/services/analysis_service/utils.py
+++ b/trailblazer/services/analysis_service/utils.py
@@ -8,17 +8,11 @@ from trailblazer.store.models import Analysis
 def get_status_counts(analyses: list[Analysis]) -> dict[TrailblazerStatus, int]:
     """Returns the amount of analyses with each status."""
     delivered: int = 0
-    status_counts: dict = {
-        TrailblazerStatus.CANCELLED: 0,
-        TrailblazerStatus.COMPLETED: 0,
-        TrailblazerStatus.FAILED: 0,
-        TrailblazerStatus.RUNNING: 0,
-    }
+    status_counts: dict = {status: 0 for status in TrailblazerStatus}
     for analysis in analyses:
         if analysis.delivery:
             delivered += 1
-            continue
-        if analysis.status in status_counts.keys():
+        else:
             status_counts[analysis.status] += 1
     status_counts["delivered"] = delivered
     return status_counts


### PR DESCRIPTION
## Description

Since we will allow users to report even non-completed analyses as delivered, the current way of counting delivered analyses will not work. This PR makes certain that a delivered analysis subtracts from the correct status count.

### Fixed

- Delivered detracts from the correct status count.

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
