### PR TITLE
Patch parsing job ids

### DIFF
--- a/trailblazer/apps/slurm/api.py
+++ b/trailblazer/apps/slurm/api.py
@@ -30,8 +30,9 @@ def cancel_slurm_job(slurm_id: int, analysis_host: str | None = None) -> None:
     subprocess.Popen(scancel_commands)
 
 
-def get_slurm_queue(job_ids: str, analysis_host: str | None = None) -> SqueueResult:
+def get_slurm_queue(job_ids: list[int], analysis_host: str | None = None) -> SqueueResult:
     """Return squeue output from ongoing analyses in SLURM."""
+    job_ids: str = ",".join(map(str, job_ids))
     queue_output: str = get_slurm_queue_output(job_ids=job_ids, analysis_host=analysis_host)
     return get_squeue_result(queue_output)
 

--- a/trailblazer/clients/slurm_cli_client/slurm_cli_client.py
+++ b/trailblazer/clients/slurm_cli_client/slurm_cli_client.py
@@ -6,5 +6,5 @@ class SlurmCLIClient:
     def __init__(self, host: str):
         self.host = host
 
-    def get_slurm_queue(self, job_ids: str) -> SqueueResult:
+    def get_slurm_queue(self, job_ids: list[int]) -> SqueueResult:
         return get_slurm_queue(job_ids=job_ids, analysis_host=self.host)

--- a/trailblazer/services/job_service/utils.py
+++ b/trailblazer/services/job_service/utils.py
@@ -11,7 +11,7 @@ def get_slurm_job_ids(job_id_file: str) -> list[int]:
     )
     job_ids: list[int] = []
     for row in content.values():
-        [job_ids.append(job_id) for job_id in row]
+        [job_ids.append(int(job_id)) for job_id in row]
     return job_ids
 
 

--- a/trailblazer/services/slurm/slurm_cli_service/slurm_cli_service.py
+++ b/trailblazer/services/slurm/slurm_cli_service/slurm_cli_service.py
@@ -15,5 +15,5 @@ class SlurmCLIService(SlurmService):
         return create_job_info_dto(job)
 
     def get_jobs(self, job_ids: list[int]) -> list[SlurmJobInfo]:
-        queue: SqueueResult = self.client.get_slurm_queue(*map(str, job_ids))
+        queue: SqueueResult = self.client.get_slurm_queue(job_ids)
         return [create_job_info_dto(job) for job in queue.jobs]


### PR DESCRIPTION
## Description
Introduced a bug in the previous refactoring of the scan command https://github.com/Clinical-Genomics/trailblazer/pull/423 when parsing and passing the parsed job ids.

Discovered it when I deployed to production today.

### Fixed
- Fix parsing of job ids

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
