### PR TITLE
Ensure old logic is used for updating tower analysis status

### DIFF
--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -1,4 +1,4 @@
-from trailblazer.constants import TrailblazerStatus
+from trailblazer.constants import TrailblazerStatus, WorkflowManager
 from trailblazer.constants import Workflow
 from trailblazer.dto import (
     AnalysesRequest,
@@ -74,6 +74,10 @@ class AnalysisService:
         analyses: list[Analysis] = self.store.get_ongoing_analyses()
         for analysis in analyses:
             self.job_service.update_jobs(analysis.id)
+
+            if analysis.workflow == WorkflowManager.TOWER:
+                continue
+
             status: TrailblazerStatus = self.job_service.get_analysis_status(analysis.id)
             progress: float = self.job_service.get_analysis_progression(analysis.id)
             self.store.update_analysis_progress(analysis_id=analysis.id, progress=progress)


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/trailblazer/issues/434.
Ensure the old logic is used for updating Tower analysis status and progress.

### Fixed
- Ensure Tower analyses status/progress are reported correctly

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
