### PR TITLE
Fix microsalt analysis status bug

### DIFF
--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -76,12 +76,12 @@ class AnalysisService:
         analyses: list[Analysis] = self.store.get_ongoing_analyses()
         for analysis in analyses:
             try:
-                self.update_analyis_meta_data(analysis)
+                self.update_analysis_meta_data(analysis)
             except Exception as error:
                 self.store.update_analysis_status(analysis.id, TrailblazerStatus.ERROR)
                 LOG.error(f"Failed to update analysis {analysis.id}: {error}")
 
-    def update_analyis_meta_data(self, analysis: Analysis):
+    def update_analysis_meta_data(self, analysis: Analysis):
         """Update the jobs, progress and status of an analysis."""
         self.job_service.update_jobs(analysis.id)
 

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -1,3 +1,4 @@
+import logging
 from trailblazer.constants import TrailblazerStatus, WorkflowManager
 from trailblazer.dto import (
     AnalysesRequest,
@@ -19,6 +20,8 @@ from trailblazer.services.analysis_service.utils import (
 from trailblazer.services.job_service.job_service import JobService
 from trailblazer.store.models import Analysis, Job, User
 from trailblazer.store.store import Store
+
+LOG = logging.getLogger(__name__)
 
 
 class AnalysisService:
@@ -72,15 +75,23 @@ class AnalysisService:
     def update_ongoing_analyses(self) -> None:
         analyses: list[Analysis] = self.store.get_ongoing_analyses()
         for analysis in analyses:
-            self.job_service.update_jobs(analysis.id)
+            try:
+                self.update_analyis_meta_data(analysis)
+            except Exception as error:
+                self.store.update_analysis_status(analysis.id, TrailblazerStatus.ERROR)
+                LOG.error(f"Failed to update analysis {analysis.id}: {error}")
 
-            if analysis.workflow_manager == WorkflowManager.TOWER:
-                continue
+    def update_analyis_meta_data(self, analysis: Analysis):
+        """Update the jobs, progress and status of an analysis."""
+        self.job_service.update_jobs(analysis.id)
 
-            status: TrailblazerStatus = self.job_service.get_analysis_status(analysis.id)
-            progress: float = self.job_service.get_analysis_progression(analysis.id)
-            self.store.update_analysis_progress(analysis_id=analysis.id, progress=progress)
-            self.store.update_analysis_status(analysis_id=analysis.id, status=status)
+        if analysis.workflow_manager == WorkflowManager.TOWER:
+            return
+
+        status: TrailblazerStatus = self.job_service.get_analysis_status(analysis.id)
+        progress: float = self.job_service.get_analysis_progression(analysis.id)
+        self.store.update_analysis_progress(analysis_id=analysis.id, progress=progress)
+        self.store.update_analysis_status(analysis_id=analysis.id, status=status)
 
     def get_summaries(self, request_data: SummariesRequest) -> SummariesResponse:
         summaries: list[Summary] = []


### PR DESCRIPTION
We have logic elsewhere which depends on this old code https://github.com/Clinical-Genomics/trailblazer/blob/0b2de899db698c269405b07c4e7fe47e97e16321/trailblazer/store/crud/update.py#L156-L160

Specifically microsalt logic.

This PR ensures the old behavior, that the status of an analysis is set to `ERROR` if anything goes wrong when updating the analysis meta data.


### Fixed
- Ensure old behavior for setting analyses to `ERROR` when they cannot be updated.


### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
