### PR TITLE
Fix job status update

### DIFF
--- a/trailblazer/exceptions.py
+++ b/trailblazer/exceptions.py
@@ -4,3 +4,7 @@ class TrailblazerError(Exception):
 
 class JobServiceError(TrailblazerError):
     pass
+
+
+class NoJobsError(JobServiceError):
+    pass

--- a/trailblazer/exceptions.py
+++ b/trailblazer/exceptions.py
@@ -1,0 +1,6 @@
+class TrailblazerError(Exception):
+    pass
+
+
+class JobServiceError(TrailblazerError):
+    pass

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -3,7 +3,7 @@ import logging
 
 from trailblazer.constants import TrailblazerStatus, WorkflowManager
 from trailblazer.dto import CreateJobRequest, FailedJobsRequest, FailedJobsResponse, JobResponse
-from trailblazer.exceptions import JobServiceError
+from trailblazer.exceptions import JobServiceError, NoJobsError
 from trailblazer.services.job_service.mappers import (
     create_failed_jobs_response,
     create_job_response,
@@ -60,6 +60,10 @@ class JobService:
 
     def get_analysis_status(self, analysis_id: int) -> TrailblazerStatus:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
+
+        if not analysis.jobs:
+            raise NoJobsError(f"No jobs found for analysis {analysis_id}")
+
         return get_status(analysis.jobs)
 
     def get_analysis_progression(self, analysis_id: int) -> float:

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -3,6 +3,7 @@ import logging
 
 from trailblazer.constants import TrailblazerStatus, WorkflowManager
 from trailblazer.dto import CreateJobRequest, FailedJobsRequest, FailedJobsResponse, JobResponse
+from trailblazer.exceptions import JobServiceError
 from trailblazer.services.job_service.mappers import (
     create_failed_jobs_response,
     create_job_response,
@@ -48,6 +49,7 @@ class JobService:
                 self.store.update_tower_run_status(analysis_id)
         except Exception as error:
             LOG.error(f"Failed to update jobs {analysis.case_id} - {analysis.id}: {error}")
+            raise JobServiceError from error
 
     def _update_slurm_jobs(self, analysis_id: int) -> None:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)


### PR DESCRIPTION
## Description
Closes https://github.com/Clinical-Genomics/trailblazer/issues/440
Ensure exception is raised when job service fails updating jobs. The caller (analysis service) will catch the exception and handle it correctly.

### Fixed
- Ensure job service raises exception when it fails

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
