### PR TITLE
Remove crossplatform option

### DIFF
--- a/.github/workflows/build_dockerfile_on_push.yml
+++ b/.github/workflows/build_dockerfile_on_push.yml
@@ -20,10 +20,6 @@ jobs:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
 
-     - name: Set up Docker Buildx
-       id: buildx
-       uses: docker/setup-buildx-action@v2.2.1
-
      - name: Build web API image
        uses: docker/build-push-action@v3.2.0
        with:

--- a/.github/workflows/build_dockerfile_on_release.yml
+++ b/.github/workflows/build_dockerfile_on_release.yml
@@ -20,10 +20,6 @@ jobs:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
 
-     - name: Set up Docker Buildx
-       id: buildx
-       uses: docker/setup-buildx-action@v2.2.1
-
      - name: Build image for web API
        uses: docker/build-push-action@v3.2.0
        with:


### PR DESCRIPTION
## Description
The containerization software we run on the cluster (Singularity) cannot run images generated with the `buildx` option. It throws errors like `unsupported schema version 2`. This is due to the software being outdated by 5 years.

The issue is resolved by removing buildx (it lets you build images for both arm64 and amd64 architectures). We only use `amd64` on our servers.

The only drawback is that our Macs use arm64, meaning that the images will not be possible to run on our local machines. I can sidestep this by reintroducing the duplication and have a separate one for the CLI images intended to run on the cluster. I'm fine with either option. I don't think anyone in our team uses the web API image locally anyway.

### Fixed
- Remove buildx option breaking old containerization software on cluster
