### PR TITLE
Include case_ids per status in Status summary

### DIFF
--- a/trailblazer/dto/summaries_response.py
+++ b/trailblazer/dto/summaries_response.py
@@ -1,15 +1,20 @@
 from pydantic import BaseModel
 
 
+class StatusSummary(BaseModel):
+    count: int = 0
+    case_ids: list[str] = []
+
+
 class Summary(BaseModel):
     order_id: int
     total: int
 
-    cancelled: int
-    completed: int
-    delivered: int
-    failed: int
-    running: int
+    cancelled: StatusSummary
+    completed: StatusSummary
+    delivered: StatusSummary
+    failed: StatusSummary
+    running: StatusSummary
 
 
 class SummariesResponse(BaseModel):

--- a/trailblazer/services/analysis_service/utils.py
+++ b/trailblazer/services/analysis_service/utils.py
@@ -1,26 +1,29 @@
 from trailblazer.constants import TrailblazerStatus
 from trailblazer.dto.analyses_response import UpdateAnalysesResponse
 from trailblazer.dto.analysis_response import AnalysisResponse
-from trailblazer.dto.summaries_response import Summary
+from trailblazer.dto.summaries_response import StatusSummary, Summary
 from trailblazer.store.models import Analysis
 
 
-def get_status_counts(analyses: list[Analysis]) -> dict[TrailblazerStatus, int]:
+def get_status_counts(analyses: list[Analysis]) -> dict[TrailblazerStatus, StatusSummary]:
     """Returns the amount of analyses with each status."""
     delivered: int = 0
-    status_counts: dict = {status: 0 for status in TrailblazerStatus}
+    delivered_cases: list[str] = []
+    status_counts: dict = {status: StatusSummary() for status in TrailblazerStatus}
     for analysis in analyses:
         if analysis.delivery:
             delivered += 1
+            delivered_cases += analysis.case_id
         else:
-            status_counts[analysis.status] += 1
-    status_counts["delivered"] = delivered
+            status_counts[analysis.status].count += 1
+            status_counts[analysis.status].case_ids.append(analysis.case_id)
+    status_counts["delivered"] = StatusSummary(count=delivered, case_ids=delivered_cases)
     return status_counts
 
 
 def create_summary(analyses: list[Analysis], order_id: int) -> Summary:
     total: int = len(analyses)
-    status_counts: dict[TrailblazerStatus, int] = get_status_counts(analyses)
+    status_counts: dict[TrailblazerStatus, StatusSummary] = get_status_counts(analyses)
     return Summary(order_id=order_id, total=total, **status_counts)
 
 

--- a/trailblazer/services/analysis_service/utils.py
+++ b/trailblazer/services/analysis_service/utils.py
@@ -13,7 +13,7 @@ def get_status_counts(analyses: list[Analysis]) -> dict[TrailblazerStatus, Statu
     for analysis in analyses:
         if analysis.delivery:
             delivered += 1
-            delivered_cases += analysis.case_id
+            delivered_cases.append(analysis.case_id)
         else:
             status_counts[analysis.status].count += 1
             status_counts[analysis.status].case_ids.append(analysis.case_id)

--- a/trailblazer/services/analysis_service/utils.py
+++ b/trailblazer/services/analysis_service/utils.py
@@ -6,7 +6,7 @@ from trailblazer.store.models import Analysis
 
 
 def get_status_counts(analyses: list[Analysis]) -> dict[TrailblazerStatus, StatusSummary]:
-    """Returns the amount of analyses with each status."""
+    """Returns the number of analyses with each status."""
     delivered: int = 0
     delivered_cases: list[str] = []
     status_counts: dict = {status: StatusSummary() for status in TrailblazerStatus}


### PR DESCRIPTION
## Description

In order to let the Trailblazer statuses rule supreme in the order status summaries, we need to know which cases have already been assigned a Trailblazer status. I decided to list them per status, so that we can also show which case has which order upon hover in CiGRID, should that be wished for.

### Changed

- case_ids per status are included in the status summary response.

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
