### PR TITLE
Add user abbreviations to the database

### DIFF
--- a/alembic/versions/2024_06_27_62d2c4418b52_add_user_abbreviations.py
+++ b/alembic/versions/2024_06_27_62d2c4418b52_add_user_abbreviations.py
@@ -1,0 +1,25 @@
+"""Add user abbreviations
+
+Revision ID: 62d2c4418b52
+Revises: a8ae3ab67bc8
+Create Date: 2024-06-27 15:55:45.434906
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "62d2c4418b52"
+down_revision = "a8ae3ab67bc8"
+branch_labels = None
+depends_on = None
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+def upgrade():
+    op.add_column(table_name="user", column=sa.Column("abbreviation", sa.String(16), unique=True))
+
+
+def downgrade():
+    op.drop_column(table_name="user", column_name="abbreviation")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,12 @@ def archived_user_email() -> str:
     return "archived.user@magnolia.com"
 
 
+@pytest.fixture
+def archived_user_abbreviation() -> str:
+    """Return an archived user abbreviation."""
+    return "AU"
+
+
 @pytest.fixture(scope="session")
 def user_email() -> str:
     """Return an user email."""
@@ -171,14 +177,22 @@ def analysis_store(
     analysis_data: dict[str, list],
     archived_user_email: str,
     archived_username: str,
+    archived_user_abbreviation: str,
     raw_analyses: list[dict],
     store: MockStore,
 ) -> Generator[MockStore, None, None]:
     """A sample Trailblazer database populated with pending analyses."""
     session: Session = get_session()
-    StoreHelpers.add_user(email=archived_user_email, name=archived_username, is_archived=True)
+    StoreHelpers.add_user(
+        email=archived_user_email,
+        name=archived_username,
+        is_archived=True,
+        abbreviation=archived_user_abbreviation,
+    )
     for user_data in analysis_data["users"]:
-        store.add_user(name=user_data["name"], email=user_data["email"])
+        store.add_user(
+            name=user_data["name"], email=user_data["email"], abbreviation=user_data["abbreviation"]
+        )
     for raw_analysis in raw_analyses:
         raw_analysis["user"] = store.get_user(email=raw_analysis["user"])
         raw_analysis["case_id"] = raw_analysis.pop("case_id")

--- a/tests/fixtures/analysis-data.yaml
+++ b/tests/fixtures/analysis-data.yaml
@@ -2,8 +2,10 @@
 users:
   - name: Paul Anderson
     email: paul.anderson@magnolia.com
+    abbreviation: PA
   - name: Tom Cruise
     email: tom.cruise@magnolia.com
+    abbreviation: TC
 
 analyses:
   - case_id: cuddlyhen

--- a/tests/store/utils/store_helper.py
+++ b/tests/store/utils/store_helper.py
@@ -1,11 +1,12 @@
 """Utility functions to simply add test data in a Trailblazer store."""
 
 from datetime import date, datetime
+
 from sqlalchemy.orm import Session
 
-from trailblazer.store.store import Store
 from trailblazer.store.database import get_session
 from trailblazer.store.models import Info, Job, User
+from trailblazer.store.store import Store
 
 
 class StoreHelpers:
@@ -40,9 +41,11 @@ class StoreHelpers:
         return job
 
     @staticmethod
-    def add_user(email: str, name: str, is_archived: bool = False) -> User:
+    def add_user(
+        email: str, name: str, is_archived: bool = False, abbreviation: str = None
+    ) -> User:
         """Add a user object to the store."""
         session: Session = get_session()
-        user = User(email=email, name=name, is_archived=is_archived)
+        user = User(email=email, name=name, is_archived=is_archived, abbreviation=abbreviation)
         session.add(user)
         return user

--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -11,6 +11,7 @@ class User(BaseModel):
     id: int
     is_archived: bool | None = False
     name: str | None = None
+    abbreviation: str | None = None
 
 
 class Job(BaseModel):

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -38,10 +38,10 @@ class CreateHandler(BaseHandler):
         session.commit()
         return new_analysis
 
-    def add_user(self, name: str, email: str) -> User:
+    def add_user(self, name: str, email: str, abbreviation: str = "") -> User:
         """Add a new user to the database."""
         session: Session = get_session()
-        new_user = User(email=email, name=name)
+        new_user = User(email=email, name=name, abbreviation=abbreviation)
         session.add(new_user)
         session.commit()
         return new_user

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -112,7 +112,7 @@ class Analysis(Model):
         return [job for job in self.jobs if job.job_type == JobType.UPLOAD]
 
     @property
-    def delivered_by(self) -> User | None:
+    def delivered_by(self) -> str | None:
         return self.delivery.user.abbreviation if self.delivery else None
 
     @property

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -113,7 +113,7 @@ class Analysis(Model):
 
     @property
     def delivered_by(self) -> User | None:
-        return self.delivery.user.name if self.delivery else None
+        return self.delivery.user.abbreviation if self.delivery else None
 
     @property
     def delivered_date(self) -> datetime.datetime | None:

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -42,6 +42,7 @@ class User(Model):
     is_archived = Column(types.Boolean, default=False)
     name = Column(types.String(128))
     refresh_token = Column(types.Text)
+    abbreviation = Column(types.String(16), unique=True)
 
     runs = orm.relationship("Analysis", backref="user")
 


### PR DESCRIPTION
## Description

This PR attempts to remedy https://github.com/Clinical-Genomics/cigrid-ui/issues/600 although a PR in cigrid-ui will be needed as well as a script. Essentially this PR adds a field to the User table to store the abbreviation of the CG employees to visualize in the FE

### Added

- User.abbreviation column

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b add-user-abbreviations -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
