### PR TITLE
Add user signatures

### DIFF
--- a/alembic/versions/2024_07_23_8184202b1654_add_abbreviation.py
+++ b/alembic/versions/2024_07_23_8184202b1654_add_abbreviation.py
@@ -1,0 +1,26 @@
+"""Add abbreviation
+
+Revision ID: 8184202b1654
+Revises: a8ae3ab67bc8
+Create Date: 2024-07-23 16:12:47.581294
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "8184202b1654"
+down_revision = "a8ae3ab67bc8"
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(
+        "user", sa.Column("abbreviation", sa.String(length=32), unique=True, nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("user", "abbreviation")

--- a/tests/cli/test_cli_core.py
+++ b/tests/cli/test_cli_core.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 import trailblazer
 from tests.mocks.store_mock import MockStore
 from trailblazer.cli.core import (
-    add_user_to_db,
+    add_user,
     archive_user,
     base,
     cancel,
@@ -345,7 +345,7 @@ def test_add_user(cli_runner: CliRunner, trailblazer_context: dict[str, MockStor
 
     # WHEN adding new user
     cli_runner.invoke(
-        add_user_to_db, ["harriers@disco.com", "--name", "Harry DuBois"], obj=trailblazer_context
+        add_user, ["harriers@disco.com", "--name", "Harry DuBois"], obj=trailblazer_context
     )
 
     # THEN log should inform that user is added
@@ -365,7 +365,7 @@ def test_add_user_when_already_exists(
     caplog.set_level("INFO")
 
     # WHEN adding new user
-    cli_runner.invoke(add_user_to_db, [user_email, "--name", username], obj=trailblazer_context)
+    cli_runner.invoke(add_user, [user_email, "--name", username], obj=trailblazer_context)
 
     # THEN log should inform that user is added
     assert f"User with email {user_email} found" in caplog.text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,11 @@ def analysis_store(
     session: Session = get_session()
     StoreHelpers.add_user(email=archived_user_email, name=archived_username, is_archived=True)
     for user_data in analysis_data["users"]:
-        store.add_user(name=user_data["name"], email=user_data["email"])
+        store.add_user(
+            name=user_data["name"],
+            email=user_data["email"],
+            abbreviation=user_data["abbreviation"],
+        )
     for raw_analysis in raw_analyses:
         raw_analysis["user"] = store.get_user(email=raw_analysis["user"])
         raw_analysis["case_id"] = raw_analysis.pop("case_id")

--- a/tests/fixtures/analysis-data.yaml
+++ b/tests/fixtures/analysis-data.yaml
@@ -2,8 +2,10 @@
 users:
   - name: Paul Anderson
     email: paul.anderson@magnolia.com
+    abbreviation: PA
   - name: Tom Cruise
     email: tom.cruise@magnolia.com
+    abbreviation: TC
 
 analyses:
   - case_id: cuddlyhen

--- a/tests/store/crud/test_create.py
+++ b/tests/store/crud/test_create.py
@@ -9,7 +9,7 @@ def test_add_user(store: MockStore, user_email: str, username: str):
     assert not store.get_query(table=User).first()
 
     # WHEN adding a new user
-    new_user: User = store.add_user(name=username, email=user_email)
+    new_user: User = store.add_user(name=username, email=user_email, abbreviation="abb")
 
     # THEN it should be stored in the database
     user: User = apply_user_filter(

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -117,15 +117,16 @@ def update_analysis(context, analysis_id: int):
 
 @base.command("add-user")
 @click.option("--name", help="Name of new user to add")
+@click.option("--abbreviation", help="Abbreviation of new user to add")
 @click.argument("email", default=environ_email())
 @click.pass_context
-def add_user_to_db(context, email: str, name: str) -> None:
+def add_user_to_db(context, email: str, name: str, abbreviation: str) -> None:
     """Add a new user to the database."""
     trailblazer_db: Store = context.obj["trailblazer_db"]
     existing_user = trailblazer_db.get_user(email=email, exclude_archived=False)
     if is_existing_user(user=existing_user, email=email):
         return
-    new_user = trailblazer_db.add_user(email=email, name=name)
+    new_user = trailblazer_db.add_user(email=email, name=name, abbreviation=abbreviation)
     LOG.info(f"New user added: {new_user.email} ({new_user.id})")
 
 

--- a/trailblazer/cli/core.py
+++ b/trailblazer/cli/core.py
@@ -120,7 +120,7 @@ def update_analysis(context, analysis_id: int):
 @click.option("--abbreviation", help="Abbreviation of new user to add")
 @click.argument("email", default=environ_email())
 @click.pass_context
-def add_user_to_db(context, email: str, name: str, abbreviation: str) -> None:
+def add_user(context, email: str, name: str, abbreviation: str) -> None:
     """Add a new user to the database."""
     trailblazer_db: Store = context.obj["trailblazer_db"]
     existing_user = trailblazer_db.get_user(email=email, exclude_archived=False)

--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -11,6 +11,7 @@ class User(BaseModel):
     id: int
     is_archived: bool | None = False
     name: str | None = None
+    abbreviation: str | None = None
 
 
 class Job(BaseModel):

--- a/trailblazer/store/crud/create.py
+++ b/trailblazer/store/crud/create.py
@@ -38,10 +38,10 @@ class CreateHandler(BaseHandler):
         session.commit()
         return new_analysis
 
-    def add_user(self, name: str, email: str) -> User:
+    def add_user(self, name: str, email: str, abbreviation: str) -> User:
         """Add a new user to the database."""
         session: Session = get_session()
-        new_user = User(email=email, name=name)
+        new_user = User(email=email, name=name, abbreviation=abbreviation)
         session.add(new_user)
         session.commit()
         return new_user

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -41,6 +41,7 @@ class User(Model):
     id = Column(types.Integer, primary_key=True)
     is_archived = Column(types.Boolean, default=False)
     name = Column(types.String(128))
+    abbreviation = Column(types.String(32), unique=True, nullable=True)
     refresh_token = Column(types.Text)
 
     runs = orm.relationship("Analysis", backref="user")

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -113,7 +113,7 @@ class Analysis(Model):
 
     @property
     def delivered_by(self) -> User | None:
-        return self.delivery.user.abbreviation if self.delivery else None
+        return self.delivery.user.name if self.delivery else None
 
     @property
     def delivered_date(self) -> datetime.datetime | None:

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -113,7 +113,7 @@ class Analysis(Model):
 
     @property
     def delivered_by(self) -> User | None:
-        return self.delivery.user.name if self.delivery else None
+        return self.delivery.user.abbreviation if self.delivery else None
 
     @property
     def delivered_date(self) -> datetime.datetime | None:


### PR DESCRIPTION
Part of resolving https://github.com/Clinical-Genomics/cigrid-ui/issues/600

This PR adds
- An abbreviation column to the user table.
- An abbreviation option to the `add-user` command.
