### PR TITLE
Filter on workflow for upload status logic

### DIFF
--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -1,5 +1,5 @@
 import logging
-from trailblazer.constants import TrailblazerStatus, WorkflowManager
+from trailblazer.constants import TrailblazerStatus, Workflow, WorkflowManager
 from trailblazer.dto import (
     AnalysesRequest,
     AnalysesResponse,
@@ -75,7 +75,7 @@ class AnalysisService:
 
     def update_uploading_analyses(self):
         self.job_service.update_upload_jobs()
-        analyses: list[Analysis] = self.store.get_fastq_analyses_being_uploaded()
+        analyses: list[Analysis] = self.store.get_analyses_being_uploaded(Workflow.FASTQ)
         for analysis in analyses:
             if upload_date := get_upload_date(analysis):
                 self.store.update_analysis_upload_date(

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -75,7 +75,7 @@ class AnalysisService:
 
     def update_uploading_analyses(self):
         self.job_service.update_upload_jobs()
-        analyses: list[Analysis] = self.store.get_analyses_being_uploaded()
+        analyses: list[Analysis] = self.store.get_fastq_analyses_being_uploaded()
         for analysis in analyses:
             if upload_date := get_upload_date(analysis):
                 self.store.update_analysis_upload_date(

--- a/trailblazer/services/analysis_service/utils.py
+++ b/trailblazer/services/analysis_service/utils.py
@@ -47,7 +47,7 @@ def create_update_analyses_response(analyses: list[Analysis]) -> UpdateAnalysesR
 
 def get_upload_date(analysis: Analysis) -> datetime | None:
     completed_job: Job | None = _get_completed_job(analysis.upload_jobs)
-    if analysis.workflow != Workflow.FASTQ or not completed_job:
+    if not completed_job:
         return
     return _get_completed_at_date(completed_job)
 

--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -4,7 +4,7 @@ from typing import Callable
 from sqlalchemy import desc
 from sqlalchemy.orm import Query
 
-from trailblazer.constants import JobType, TrailblazerStatus
+from trailblazer.constants import JobType, TrailblazerStatus, Workflow
 from trailblazer.dto.analyses_request import AnalysesRequest
 from trailblazer.store.base import BaseHandler
 from trailblazer.store.filters.analyses_filters import AnalysisFilter, apply_analysis_filter
@@ -253,8 +253,13 @@ class ReadHandler(BaseHandler):
             page_size=request.page_size,
         )
 
-    def get_analyses_being_uploaded(self) -> list[Analysis]:
+    def get_fastq_analyses_being_uploaded(self) -> list[Analysis]:
         return apply_analysis_filter(
-            filter_functions=[AnalysisFilter.BY_NOT_UPLOADED, AnalysisFilter.BY_COMPLETED],
+            filter_functions=[
+                AnalysisFilter.BY_NOT_UPLOADED,
+                AnalysisFilter.BY_COMPLETED,
+                AnalysisFilter.BY_WORKFLOW,
+            ],
             analyses=self.get_query(Analysis),
+            workflow=Workflow.FASTQ,
         ).all()

--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -253,7 +253,7 @@ class ReadHandler(BaseHandler):
             page_size=request.page_size,
         )
 
-    def get_fastq_analyses_being_uploaded(self) -> list[Analysis]:
+    def get_analyses_being_uploaded(self, workflow: Workflow) -> list[Analysis]:
         return apply_analysis_filter(
             filter_functions=[
                 AnalysisFilter.BY_NOT_UPLOADED,
@@ -261,5 +261,5 @@ class ReadHandler(BaseHandler):
                 AnalysisFilter.BY_WORKFLOW,
             ],
             analyses=self.get_query(Analysis),
-            workflow=Workflow.FASTQ,
+            workflow=workflow,
         ).all()


### PR DESCRIPTION
Small cleanup, more efficient to filter out any non-fastq analyses earlier on since those are the only analyses we want to set the upload date for automatically currently.