### PR TITLE
Patch tower analysis status update

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,14 @@ from tests.mocks.store_mock import MockStore
 from tests.store.utils.store_helper import StoreHelpers
 from trailblazer.clients.slurm_api_client.dto.common import SlurmAPIJobInfo
 from trailblazer.clients.slurm_api_client.dto.job_response import SlurmJobResponse
-from trailblazer.clients.tower.models import TaskWrapper, TowerTask, TowerTasksResponse
+from trailblazer.clients.tower.models import (
+    TaskWrapper,
+    TowerProgress,
+    TowerTask,
+    TowerTasksResponse,
+    TowerWorkflow,
+    TowerWorkflowResponse,
+)
 from trailblazer.constants import (
     PRIORITY_OPTIONS,
     TOWER_TIMESTAMP_FORMAT,
@@ -351,6 +358,16 @@ def tower_tasks_response():
     task_wrapper_1 = TaskWrapper(task=task_1)
     task_wrapper_2 = TaskWrapper(task=task_2)
     return TowerTasksResponse(tasks=[task_wrapper_1, task_wrapper_2], total=2)
+
+
+@pytest.fixture
+def tower_workflow_response() -> TowerWorkflowResponse:
+    worfklow = TowerWorkflow(status="RUNNING")
+    progress = TowerProgress(workflowProgress={}, processesProgress=[])
+    return TowerWorkflowResponse(
+        workflow=worfklow,
+        progress=progress,
+    )
 
 
 @pytest.fixture

--- a/tests/integration/services/analysis_service/test_analysis_service.py
+++ b/tests/integration/services/analysis_service/test_analysis_service.py
@@ -1,5 +1,5 @@
 from trailblazer.clients.slurm_api_client.dto.job_response import SlurmJobResponse
-from trailblazer.clients.tower.models import TowerTasksResponse
+from trailblazer.clients.tower.models import TowerTasksResponse, TowerWorkflowResponse
 from trailblazer.constants import TrailblazerStatus
 from trailblazer.services.analysis_service.analysis_service import AnalysisService
 from trailblazer.store.models import Analysis
@@ -9,10 +9,12 @@ def test_updating_tower_analysis(
     analysis_service: AnalysisService,
     tower_analysis: Analysis,
     tower_tasks_response: TowerTasksResponse,
+    tower_workflow_response: TowerWorkflowResponse,
 ):
 
     # GIVEN an analysis started with tower without any job entries but running tasks
     analysis_service.job_service.tower_service.client.get_tasks.return_value = tower_tasks_response
+    analysis_service.job_service.tower_service.client.get_workflow.return_value = tower_workflow_response
 
     # WHEN updating the tower analysis
     analysis_service.update_analysis_meta_data(tower_analysis.id)

--- a/tests/integration/services/analysis_service/test_analysis_service.py
+++ b/tests/integration/services/analysis_service/test_analysis_service.py
@@ -14,7 +14,9 @@ def test_updating_tower_analysis(
 
     # GIVEN an analysis started with tower without any job entries but running tasks
     analysis_service.job_service.tower_service.client.get_tasks.return_value = tower_tasks_response
-    analysis_service.job_service.tower_service.client.get_workflow.return_value = tower_workflow_response
+    analysis_service.job_service.tower_service.client.get_workflow.return_value = (
+        tower_workflow_response
+    )
 
     # WHEN updating the tower analysis
     analysis_service.update_analysis_meta_data(tower_analysis.id)

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -64,13 +64,10 @@ class JobService:
         if not analysis.jobs:
             raise NoJobsError(f"No jobs found for analysis {analysis_id}")
 
-        status: TrailblazerStatus = get_status(analysis.jobs)
-        if (
-            analysis.workflow_manager == WorkflowManager.TOWER
-            and status == TrailblazerStatus.COMPLETED
-        ):
-            status = TrailblazerStatus.QC
-        return status
+        if analysis.workflow_manager == WorkflowManager.TOWER:
+            return self.tower_service.get_status(analysis_id)
+
+        return get_status(analysis.jobs)
 
     def get_analysis_progression(self, analysis_id: int) -> float:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)

--- a/trailblazer/services/tower/tower_api_service.py
+++ b/trailblazer/services/tower/tower_api_service.py
@@ -1,5 +1,6 @@
 from trailblazer.clients.tower.models import TowerTasksResponse
 from trailblazer.clients.tower.tower_client import TowerAPIClient
+from trailblazer.constants import TOWER_WORKFLOW_STATUS, TrailblazerStatus
 from trailblazer.services.tower.utils import create_job_from_tower_task, get_tower_workflow_id
 from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
@@ -24,3 +25,10 @@ class TowerAPIService:
         workflow_id: str = get_tower_workflow_id(analysis)
         self.client.cancel_workflow(workflow_id)
         self.update_jobs(analysis_id)
+
+    def get_status(self, workflow_id: str) -> str:
+        response = self.client.get_workflow(workflow_id)
+        status = TOWER_WORKFLOW_STATUS.get(response.workflow.status, TrailblazerStatus.ERROR)
+        if status == TrailblazerStatus.COMPLETED:
+            return TrailblazerStatus.QC
+        return status

--- a/trailblazer/services/tower/tower_api_service.py
+++ b/trailblazer/services/tower/tower_api_service.py
@@ -26,7 +26,7 @@ class TowerAPIService:
         self.client.cancel_workflow(workflow_id)
         self.update_jobs(analysis_id)
 
-    def get_status(self, workflow_id: str) -> str:
+    def get_status(self, workflow_id: str) -> TrailblazerStatus:
         response = self.client.get_workflow(workflow_id)
         status = TOWER_WORKFLOW_STATUS.get(response.workflow.status, TrailblazerStatus.ERROR)
         if status == TrailblazerStatus.COMPLETED:


### PR DESCRIPTION
We prematurely set the status of tower analyses to QC due to not taking into account that all jobs in a workflow can be completed without the workflow itself being completed.