### PR TITLE
Add analysis in cancel response

### DIFF
--- a/trailblazer/dto/cancel_analysis_response.py
+++ b/trailblazer/dto/cancel_analysis_response.py
@@ -1,5 +1,0 @@
-from pydantic import BaseModel
-
-
-class CancelAnalysisResponse(BaseModel):
-    message: str = "Analysis cancelled successfully."

--- a/trailblazer/server/api.py
+++ b/trailblazer/server/api.py
@@ -19,7 +19,6 @@ from trailblazer.dto import (
 )
 from trailblazer.dto.analyses_response import UpdateAnalysesResponse
 from trailblazer.dto.authentication.code_exchange_request import CodeExchangeRequest
-from trailblazer.dto.cancel_analysis_response import CancelAnalysisResponse
 from trailblazer.dto.create_analysis_request import CreateAnalysisRequest
 from trailblazer.dto.summaries_request import SummariesRequest
 from trailblazer.dto.summaries_response import SummariesResponse
@@ -119,7 +118,7 @@ def cancel_analysis(
     analysis_id: int,
     analysis_service: AnalysisService = Provide[Container.analysis_service],
 ):
-    response: CancelAnalysisResponse = analysis_service.cancel_analysis_from_web(analysis_id)
+    response: AnalysisResponse = analysis_service.cancel_analysis_from_web(analysis_id)
     return jsonify(response.model_dump()), HTTPStatus.OK
 
 

--- a/trailblazer/services/analysis_service/analysis_service.py
+++ b/trailblazer/services/analysis_service/analysis_service.py
@@ -8,7 +8,6 @@ from trailblazer.dto import (
     CreateAnalysisRequest,
 )
 from trailblazer.dto.analyses_response import UpdateAnalysesResponse
-from trailblazer.dto.cancel_analysis_response import CancelAnalysisResponse
 from trailblazer.dto.summaries_request import SummariesRequest
 from trailblazer.dto.summaries_response import SummariesResponse, Summary
 from trailblazer.dto.update_analyses import UpdateAnalyses
@@ -42,13 +41,14 @@ class AnalysisService:
             comment="Analysis cancelled manually",
         )
 
-    def cancel_analysis_from_web(self, analysis_id: int) -> CancelAnalysisResponse:
+    def cancel_analysis_from_web(self, analysis_id: int) -> AnalysisResponse:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
 
         if analysis.workflow_manager == WorkflowManager.SLURM:
             raise CancelSlurmAnalysisNotSupportedError()
 
         self.cancel_analysis(analysis_id)
+        return create_analysis_response(analysis)
 
     def get_analyses(self, request: AnalysesRequest) -> AnalysesResponse:
         analyses, total_count = self.store.get_paginated_analyses(request)


### PR DESCRIPTION
Include the updated analysis in the response from the `/cancel` endpoint.