### PR TITLE
Extract slurm client error handling

### DIFF
--- a/trailblazer/clients/slurm_api_client/error_handler.py
+++ b/trailblazer/clients/slurm_api_client/error_handler.py
@@ -2,7 +2,8 @@ from functools import wraps
 import logging
 
 from pydantic import ValidationError
-import requests
+from requests import HTTPError
+
 
 from trailblazer.exc import ResponseDeserializationError, SlurmAPIClientError
 
@@ -15,11 +16,11 @@ def handle_errors(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except requests.exceptions.HTTPError as e:
-            LOG.error(f"Error getting job: {e.response.content}")
-            raise SlurmAPIClientError(e)
+        except HTTPError as e:
+            LOG.error(f"Error for request in slurm API client: {e.response.content}")
+            raise SlurmAPIClientError()
         except ValidationError as e:
-            LOG.error(f"Error deserializing job response: {e}")
-            raise ResponseDeserializationError(e)
+            LOG.error(f"Error deserializing slurm API response: {e}")
+            raise ResponseDeserializationError()
 
     return wrapper

--- a/trailblazer/clients/slurm_api_client/error_handler.py
+++ b/trailblazer/clients/slurm_api_client/error_handler.py
@@ -1,0 +1,25 @@
+from functools import wraps
+import logging
+
+from pydantic import ValidationError
+import requests
+
+from trailblazer.exc import ResponseDeserializationError, SlurmAPIClientError
+
+LOG = logging.getLogger(__name__)
+
+
+def handle_errors(func):
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except requests.exceptions.HTTPError as e:
+            LOG.error(f"Error getting job: {e.response.content}")
+            raise SlurmAPIClientError(e)
+        except ValidationError as e:
+            LOG.error(f"Error deserializing job response: {e}")
+            raise ResponseDeserializationError(e)
+
+    return wrapper

--- a/trailblazer/clients/slurm_api_client/slurm_api_client.py
+++ b/trailblazer/clients/slurm_api_client/slurm_api_client.py
@@ -1,13 +1,7 @@
-import logging
-from pydantic import ValidationError
 import requests
 
 from trailblazer.clients.slurm_api_client.dto import SlurmJobResponse
 from trailblazer.clients.slurm_api_client.error_handler import handle_errors
-from trailblazer.exc import ResponseDeserializationError, SlurmAPIClientError
-
-
-LOG = logging.getLogger(__name__)
 
 
 class SlurmAPIClient:

--- a/trailblazer/clients/slurm_api_client/slurm_api_client.py
+++ b/trailblazer/clients/slurm_api_client/slurm_api_client.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 import requests
 
 from trailblazer.clients.slurm_api_client.dto import SlurmJobResponse
+from trailblazer.clients.slurm_api_client.error_handler import handle_errors
 from trailblazer.exc import ResponseDeserializationError, SlurmAPIClientError
 
 
@@ -14,26 +15,15 @@ class SlurmAPIClient:
         self.base_url = base_url
         self.headers = {"X-SLURM-USER-NAME": user_name, "X-SLURM-USER-TOKEN": access_token}
 
+    @handle_errors
     def get_job(self, job_id: str) -> SlurmJobResponse:
         endpoint: str = f"{self.base_url}/slurm/v0.0.40/job/{job_id}"
-        try:
-            response = requests.get(endpoint, headers=self.headers)
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            LOG.error(f"Error getting job {job_id}: {e.response.content}")
-            raise SlurmAPIClientError(e)
+        response = requests.get(endpoint, headers=self.headers)
+        response.raise_for_status()
+        return SlurmJobResponse.model_validate(response.json())
 
-        try:
-            return SlurmJobResponse.model_validate(response.json())
-        except ValidationError as e:
-            LOG.error(f"Error deserializing job response: {e}")
-            raise ResponseDeserializationError(e)
-
+    @handle_errors
     def cancel_job(self, job_id: str) -> None:
         endpoint: str = f"{self.base_url}/slurm/v0.0.40/job/{job_id}"
-        try:
-            response = requests.delete(endpoint, headers=self.headers)
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            LOG.error(f"Error cancelling job {job_id}: {e.response.content}")
-            raise SlurmAPIClientError(e)
+        response = requests.delete(endpoint, headers=self.headers)
+        response.raise_for_status()


### PR DESCRIPTION
The error handling does not belong in the client. This PR extracts it to a separate wrapper.