### PR TITLE
Add tower workflow id to analysis

### DIFF
--- a/alembic/versions/2024_08_26_2e86e302d6f7_add_tower_id_to_analysis.py
+++ b/alembic/versions/2024_08_26_2e86e302d6f7_add_tower_id_to_analysis.py
@@ -1,0 +1,25 @@
+"""Add tower id to analysis
+
+Revision ID: 2e86e302d6f7
+Revises: e0f217219a92
+Create Date: 2024-08-26 12:50:57.070853
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "2e86e302d6f7"
+down_revision = "e0f217219a92"
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+def upgrade():
+    op.add_column("analysis", sa.Column("tower_workflow_id", sa.String(length=32), nullable=True))
+
+
+def downgrade():
+    op.drop_column("analysis", "tower_workflow_id")

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -92,6 +92,7 @@ class Analysis(Model):
     version = Column(types.String(32))
     workflow = Column(types.String(32))
     workflow_manager = Column(types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM)
+    tower_workflow_id = Column(types.String(32))
 
     jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
     delivery = orm.relationship("Delivery", uselist=False)

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -92,7 +92,7 @@ class Analysis(Model):
     version = Column(types.String(32))
     workflow = Column(types.String(32))
     workflow_manager = Column(types.Enum(*WorkflowManager.list()), default=WorkflowManager.SLURM)
-    tower_workflow_id = Column(types.String(32))
+    tower_workflow_id = Column(types.String(32), nullable=True, default=None)
 
     jobs = orm.relationship("Job", cascade="all,delete", backref="analysis")
     delivery = orm.relationship("Delivery", uselist=False)


### PR DESCRIPTION
Part of resolving https://github.com/Clinical-Genomics/cigrid-ui/issues/672

This PR adds a tower workflow id column to the analysis table in trailblazer. It is really inconvenient and messy to try to read the file with the id from Hasta in the VM.

After the refactoring https://github.com/Clinical-Genomics/trailblazer/pull/463, the tower and slurm logic has been separated cleanly into different modules and there is no need to resort to the slurm shenanigans for tower analyses.