### PR TITLE
Move cancellable logic to BE

### DIFF
--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -53,3 +53,4 @@ class AnalysisResponse(BaseModel):
     version: str | None = None
     workflow: str | None = None
     workflow_manager: WorkflowManager
+    is_cancellable: bool = False

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -123,8 +123,7 @@ class Analysis(Model):
     @property
     def is_cancellable(self) -> bool:
         return (
-            self.status == TrailblazerStatus.PENDING
-            or self.status == TrailblazerStatus.RUNNING
+            self.status in [TrailblazerStatus.PENDING, TrailblazerStatus.RUNNING]
             and self.workflow_manager == WorkflowManager.TOWER
         )
 

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -120,6 +120,14 @@ class Analysis(Model):
     def delivered_date(self) -> datetime.datetime | None:
         return self.delivery.delivered_date if self.delivery else None
 
+    @property
+    def is_cancellable(self) -> bool:
+        return (
+            self.status == TrailblazerStatus.PENDING
+            or self.status == TrailblazerStatus.RUNNING
+            and self.workflow_manager == WorkflowManager.TOWER
+        )
+
     def to_dict(self) -> dict:
         """Return a dictionary representation of the object."""
         return {
@@ -146,6 +154,7 @@ class Analysis(Model):
             "ticket_id": self.ticket_id,
             "uploaded_at": self.uploaded_at,
             "workflow_manager": self.workflow_manager,
+            "is_cancellable": self.is_cancellable,
         }
 
 


### PR DESCRIPTION
The FE becomes less bloated with business logic if we shift the complex conditionals to the backend instead.

When you need conditional rendering for a component, it is cleaner to provide the calculated value for that conditional from the BE rather than spreading such logic throughout the FE code.