### PR TITLE
Remove tower workflow file interactions

### DIFF
--- a/trailblazer/services/job_service/utils.py
+++ b/trailblazer/services/job_service/utils.py
@@ -1,6 +1,7 @@
 from trailblazer.constants import JobType, SlurmJobStatus, TrailblazerStatus
 from trailblazer.store.models import Job
 
+
 def get_status(jobs: list[Job]) -> TrailblazerStatus:
     if has_same_status(jobs):
         return get_single_status(jobs)

--- a/trailblazer/services/job_service/utils.py
+++ b/trailblazer/services/job_service/utils.py
@@ -1,14 +1,5 @@
-from pathlib import Path
-from trailblazer.constants import FileFormat, JobType, SlurmJobStatus, TrailblazerStatus
-from trailblazer.io.controller import ReadFile
-from trailblazer.store.models import Analysis, Job
-
-
-def get_tower_workflow_id(analysis: Analysis) -> str:
-    file = Path(analysis.config_path)
-    content: dict = ReadFile.get_content_from_file(file_format=FileFormat.YAML, file_path=file)
-    return content.get(analysis.case_id)[-1]
-
+from trailblazer.constants import JobType, SlurmJobStatus, TrailblazerStatus
+from trailblazer.store.models import Job
 
 def get_status(jobs: list[Job]) -> TrailblazerStatus:
     if has_same_status(jobs):

--- a/trailblazer/services/tower/tower_api_service.py
+++ b/trailblazer/services/tower/tower_api_service.py
@@ -2,7 +2,7 @@ from trailblazer.clients.tower.models import TowerTasksResponse
 from trailblazer.clients.tower.tower_client import TowerAPIClient
 from trailblazer.constants import TOWER_WORKFLOW_STATUS, TrailblazerStatus
 from trailblazer.services.tower.error_handler import handle_errors
-from trailblazer.services.tower.utils import create_job_from_tower_task, get_tower_workflow_id
+from trailblazer.services.tower.utils import create_job_from_tower_task
 from trailblazer.store.models import Analysis, Job
 from trailblazer.store.store import Store
 

--- a/trailblazer/services/tower/tower_api_service.py
+++ b/trailblazer/services/tower/tower_api_service.py
@@ -17,8 +17,7 @@ class TowerAPIService:
     @handle_errors
     def update_jobs(self, analysis_id: int) -> list[Job]:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
-        workflow_id: str = get_tower_workflow_id(analysis)
-        response: TowerTasksResponse = self.client.get_tasks(workflow_id)
+        response: TowerTasksResponse = self.client.get_tasks(analysis.tower_workflow_id)
         jobs: list[Job] = [create_job_from_tower_task(task) for task in response.get_tasks()]
         self.store.replace_jobs(analysis_id=analysis_id, jobs=jobs)
 
@@ -31,8 +30,7 @@ class TowerAPIService:
     @handle_errors
     def get_status(self, analysis_id: int) -> TrailblazerStatus:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
-        workflow_id: str = get_tower_workflow_id(analysis)
-        response = self.client.get_workflow(workflow_id)
+        response = self.client.get_workflow(analysis.tower_workflow_id)
         status = TOWER_WORKFLOW_STATUS.get(response.workflow.status, TrailblazerStatus.ERROR)
         if status == TrailblazerStatus.COMPLETED:
             return TrailblazerStatus.QC

--- a/trailblazer/services/tower/utils.py
+++ b/trailblazer/services/tower/utils.py
@@ -1,14 +1,5 @@
-from pathlib import Path
 from trailblazer.clients.tower.models import TowerTask
-from trailblazer.constants import FileFormat
-from trailblazer.io.controller import ReadFile
-from trailblazer.store.models import Analysis, Job
-
-
-def get_tower_workflow_id(analysis: Analysis) -> str:
-    file = Path(analysis.config_path)
-    content: dict = ReadFile.get_content_from_file(file_format=FileFormat.YAML, file_path=file)
-    return content.get(analysis.case_id)[-1]
+from trailblazer.store.models import Job
 
 
 def create_job_from_tower_task(task: TowerTask) -> Job:


### PR DESCRIPTION
Blocked by https://github.com/Clinical-Genomics/IT-issues/issues/874 for production

I missed some instances where we still interact with the workflow file instead of using the workflow id stored in the database on the analysis.

Tested in stage, everything works.

### Fixed

- Swapped out old workflow file interactions when handling nf_tower analyses.

## Steps to test
1. Queue workflow run with `cg workflow rnafusion start cuddlyhen` in stage.
2. Go to cigrid and cancel analysis
3. Verify that the analysis is cancelled in tower as well https://cg-tower-stage.scilifelab.se

https://github.com/user-attachments/assets/67474cf7-66fd-496e-8001-8f41fb361cb5



