### PR TITLE
Patch pending tower analyses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,10 +362,20 @@ def tower_tasks_response():
 
 @pytest.fixture
 def tower_workflow_response() -> TowerWorkflowResponse:
-    worfklow = TowerWorkflow(status="RUNNING")
+    workflow = TowerWorkflow(status="RUNNING")
     progress = TowerProgress(workflowProgress={}, processesProgress=[])
     return TowerWorkflowResponse(
-        workflow=worfklow,
+        workflow=workflow,
+        progress=progress,
+    )
+
+
+@pytest.fixture
+def tower_response_submitted() -> TowerWorkflowResponse:
+    workflow = TowerWorkflow(status="SUBMITTED")
+    progress = TowerProgress(workflowProgress={}, processesProgress=[])
+    return TowerWorkflowResponse(
+        workflow=workflow,
         progress=progress,
     )
 

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -170,21 +170,8 @@ def analysis_service(analysis_store: Store, job_service_mock: JobService) -> Ana
 
 @pytest.fixture
 def tower_analysis_without_jobs_and_pending(analysis_store: Store):
-    analysis = Analysis(
-        config_path="config_path",
-        workflow="workflow",
-        case_id="case_id",
-        out_dir="out_dir",
-        priority=PRIORITY_OPTIONS[0],
-        started_at=datetime.now() - timedelta(weeks=1),
-        status=TrailblazerStatus.PENDING,
-        ticket_id="ticket_id",
-        type=TYPES[0],
-        workflow_manager=WorkflowManager.TOWER,
-        is_visible=True,
-        order_id=1,
-    )
-    session: Session = get_session()
-    session.add(analysis)
-    session.commit()
+    ## Create an CreateAnalysisRequest object
+    ## Use Store to add the analysis
+    ## Return the STORE
+    ## Use a specific name to test that your analysis is found
     return analysis

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -176,7 +176,7 @@ def tower_analysis_without_jobs_and_pending(analysis_store: Store):
         out_dir="out_dir",
         priority=PRIORITY_OPTIONS[0],
         started_at=datetime.now() - timedelta(weeks=1),
-        status=TrailblazerStatus.PENDING, #TODO: Issue analyses are not allowed to have `SUBMITTED` (Lets add it)
+        status=TrailblazerStatus.PENDING,
         ticket_id="ticket_id",
         type=TYPES[0],
         workflow_manager=WorkflowManager.TOWER,

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -167,6 +167,7 @@ def analysis_without_jobs(analysis_store: Store):
 def analysis_service(analysis_store: Store, job_service_mock: JobService) -> AnalysisService:
     return AnalysisService(store=analysis_store, job_service=job_service_mock)
 
+
 @pytest.fixture
 def tower_analysis_without_jobs_and_pending(analysis_store: Store):
     analysis = Analysis(
@@ -187,4 +188,3 @@ def tower_analysis_without_jobs_and_pending(analysis_store: Store):
     session.add(analysis)
     session.commit()
     return analysis
-

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -166,3 +166,25 @@ def analysis_without_jobs(analysis_store: Store):
 @pytest.fixture
 def analysis_service(analysis_store: Store, job_service_mock: JobService) -> AnalysisService:
     return AnalysisService(store=analysis_store, job_service=job_service_mock)
+
+@pytest.fixture
+def tower_analysis_without_jobs_and_pending(analysis_store: Store):
+    analysis = Analysis(
+        config_path="config_path",
+        workflow="workflow",
+        case_id="case_id",
+        out_dir="out_dir",
+        priority=PRIORITY_OPTIONS[0],
+        started_at=datetime.now() - timedelta(weeks=1),
+        status=TrailblazerStatus.PENDING, #TODO: Issue analyses are not allowed to have `SUBMITTED` (Lets add it)
+        ticket_id="ticket_id",
+        type=TYPES[0],
+        workflow_manager=WorkflowManager.TOWER,
+        is_visible=True,
+        order_id=1,
+    )
+    session: Session = get_session()
+    session.add(analysis)
+    session.commit()
+    return analysis
+

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, Mock
+
 import pytest
 from sqlalchemy.orm import Session
-
 
 from trailblazer.clients.tower.tower_client import TowerAPIClient
 from trailblazer.constants import (
@@ -166,12 +166,3 @@ def analysis_without_jobs(analysis_store: Store):
 @pytest.fixture
 def analysis_service(analysis_store: Store, job_service_mock: JobService) -> AnalysisService:
     return AnalysisService(store=analysis_store, job_service=job_service_mock)
-
-
-@pytest.fixture
-def tower_analysis_without_jobs_and_pending(analysis_store: Store):
-    ## Create an CreateAnalysisRequest object
-    ## Use Store to add the analysis
-    ## Return the STORE
-    ## Use a specific name to test that your analysis is found
-    return analysis

--- a/tests/services/test_job_service.py
+++ b/tests/services/test_job_service.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from trailblazer.clients.tower.models import TowerWorkflowResponse
@@ -69,10 +67,16 @@ def test_tower_analysis_status_pending_no_jobs(
     job_service: JobService,
     tower_analysis_without_jobs_and_pending: Analysis,
     tower_workflow_response: TowerWorkflowResponse,
+    ## Add the analysis store fixture
 ):
+
+    ### Inject the analysis store into the job service
+    ### assert your created analysis is there
+
+    ### do the test...
     # GIVEN a Tower analysis with no jobs and a SUBMITTED status
     job_service.tower_service.client.get_workflow.return_value = tower_workflow_response
-
+    # set the job service store to the analysis store in the conftest
     # Simulate a SUBMITTED workflow status from Tower
     tower_workflow_response.workflow.status = TowerStatus.SUBMITTED
 

--- a/tests/services/test_job_service.py
+++ b/tests/services/test_job_service.py
@@ -1,7 +1,7 @@
 import pytest
 
 from trailblazer.clients.tower.models import TowerWorkflowResponse
-from trailblazer.constants import TrailblazerStatus, TowerStatus
+from trailblazer.constants import TrailblazerStatus, WorkflowManager
 from trailblazer.exceptions import NoJobsError
 from trailblazer.services.job_service import JobService
 from trailblazer.store.models import Analysis
@@ -63,31 +63,33 @@ def test_analysis_status_when_running_jobs(
     assert status == TrailblazerStatus.RUNNING
 
 
-def test_tower_analysis_status_pending_no_jobs(
+def test_fetch_pending_status_for_tower_without_jobs(
     job_service: JobService,
-    tower_analysis_without_jobs_and_pending: Analysis,
-    tower_workflow_response: TowerWorkflowResponse,
-    ## Add the analysis store fixture
+    tower_response_submitted: TowerWorkflowResponse,
 ):
+    """
+    Verify that a Tower-managed analysis with no associated jobs returns a PENDING status
+    when Tower reports the workflow as submitted.
+    """
+    # GIVEN a Tower analysis with workflow manager nf_tower and without jobs
+    analysis: Analysis = job_service.store.get_query(Analysis).first()
+    analysis.workflow_manager = WorkflowManager.TOWER
+    assert not analysis.jobs
 
-    ### Inject the analysis store into the job service
-    ### assert your created analysis is there
-
-    ### do the test...
-    # GIVEN a Tower analysis with no jobs and a SUBMITTED status
-    job_service.tower_service.client.get_workflow.return_value = tower_workflow_response
-    # set the job service store to the analysis store in the conftest
-    # Simulate a SUBMITTED workflow status from Tower
-    tower_workflow_response.workflow.status = TowerStatus.SUBMITTED
+    # GIVEN a simulated response from tower with the return status being submitted
+    job_service.tower_service.client.get_workflow.return_value = tower_response_submitted
 
     # WHEN fetching the analysis status
-    status = job_service.get_analysis_status(tower_analysis_without_jobs_and_pending.id)
+    status: TrailblazerStatus = job_service.get_analysis_status(analysis.id)
 
     # THEN the analysis status should be PENDING
     assert status == TrailblazerStatus.PENDING
 
 
 def test_no_jobs_error_for_slurm_analysis(job_service: JobService, analysis_without_jobs: Analysis):
+    """
+    Ensure that a NoJobsError is raised for a SLURM analysis with no associated jobs.
+    """
     # GIVEN an analysis without any associated jobs
     # WHEN fetching the analysis status
     # THEN a NoJobsError should be raised

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -139,7 +139,7 @@ class TrailblazerStatusColor(StrEnum):
 
 
 class TowerStatus(StrEnum):
-    """Tower statuses"""
+    """Tower statuses."""
 
     ABORTED: str = "ABORTED"
     CACHED: str = "CACHED"

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -118,6 +118,7 @@ class TrailblazerStatus(StrEnum):
     PENDING: str = "pending"
     QC: str = "qc"
     RUNNING: str = "running"
+    SUBMITTED: str = "submitted"
 
     @classmethod
     def statuses(cls) -> tuple:
@@ -137,18 +138,32 @@ class TrailblazerStatusColor(StrEnum):
     PENDING: str = "yellow"
     RUNNING: str = "blue"
 
+class TowerStatus(StrEnum):
+    """Tower statuses"""
+
+    ABORTED: str = "ABORTED"
+    CACHED: str = "CACHED"
+    CANCELLED: str = "CANCELLED"
+    COMPLETED: str = "COMPLETED"
+    FAILED: str = "FAILED"
+    NEW: str = "NEW"
+    RUNNING: str = "RUNNING"
+    SUBMITTED: str = "SUBMITTED"
+    SUCCEEDED: str = "SUCCEEDED"
+    UNKNOWN: str = "UNKNOWN"
+
 
 TOWER_WORKFLOW_STATUS: dict[str, str] = {
-    "ABORTED": TrailblazerStatus.FAILED,
-    "CACHED": TrailblazerStatus.COMPLETED,
-    "CANCELLED": TrailblazerStatus.CANCELLED,
-    "COMPLETED": TrailblazerStatus.COMPLETED,
-    "FAILED": TrailblazerStatus.FAILED,
-    "NEW": TrailblazerStatus.PENDING,
-    "RUNNING": TrailblazerStatus.RUNNING,
-    "SUBMITTED": TrailblazerStatus.PENDING,
-    "SUCCEEDED": TrailblazerStatus.COMPLETED,
-    "UNKNOWN": TrailblazerStatus.FAILED,
+    TowerStatus.ABORTED : TrailblazerStatus.FAILED,
+    TowerStatus.CACHED : TrailblazerStatus.COMPLETED,
+    TowerStatus.CANCELLED : TrailblazerStatus.CANCELLED,
+    TowerStatus.COMPLETED : TrailblazerStatus.COMPLETED,
+    TowerStatus.FAILED : TrailblazerStatus.FAILED,
+    TowerStatus.NEW : TrailblazerStatus.PENDING,
+    TowerStatus.RUNNING : TrailblazerStatus.RUNNING,
+    TowerStatus.SUBMITTED : TrailblazerStatus.PENDING,
+    TowerStatus.SUCCEEDED : TrailblazerStatus.COMPLETED,
+    TowerStatus.UNKNOWN : TrailblazerStatus.FAILED,
 }
 
 

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -118,7 +118,6 @@ class TrailblazerStatus(StrEnum):
     PENDING: str = "pending"
     QC: str = "qc"
     RUNNING: str = "running"
-    SUBMITTED: str = "submitted"
 
     @classmethod
     def statuses(cls) -> tuple:

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -137,6 +137,7 @@ class TrailblazerStatusColor(StrEnum):
     PENDING: str = "yellow"
     RUNNING: str = "blue"
 
+
 class TowerStatus(StrEnum):
     """Tower statuses"""
 
@@ -153,16 +154,16 @@ class TowerStatus(StrEnum):
 
 
 TOWER_WORKFLOW_STATUS: dict[str, str] = {
-    TowerStatus.ABORTED : TrailblazerStatus.FAILED,
-    TowerStatus.CACHED : TrailblazerStatus.COMPLETED,
-    TowerStatus.CANCELLED : TrailblazerStatus.CANCELLED,
-    TowerStatus.COMPLETED : TrailblazerStatus.COMPLETED,
-    TowerStatus.FAILED : TrailblazerStatus.FAILED,
-    TowerStatus.NEW : TrailblazerStatus.PENDING,
-    TowerStatus.RUNNING : TrailblazerStatus.RUNNING,
-    TowerStatus.SUBMITTED : TrailblazerStatus.PENDING,
-    TowerStatus.SUCCEEDED : TrailblazerStatus.COMPLETED,
-    TowerStatus.UNKNOWN : TrailblazerStatus.FAILED,
+    TowerStatus.ABORTED: TrailblazerStatus.FAILED,
+    TowerStatus.CACHED: TrailblazerStatus.COMPLETED,
+    TowerStatus.CANCELLED: TrailblazerStatus.CANCELLED,
+    TowerStatus.COMPLETED: TrailblazerStatus.COMPLETED,
+    TowerStatus.FAILED: TrailblazerStatus.FAILED,
+    TowerStatus.NEW: TrailblazerStatus.PENDING,
+    TowerStatus.RUNNING: TrailblazerStatus.RUNNING,
+    TowerStatus.SUBMITTED: TrailblazerStatus.PENDING,
+    TowerStatus.SUCCEEDED: TrailblazerStatus.COMPLETED,
+    TowerStatus.UNKNOWN: TrailblazerStatus.FAILED,
 }
 
 

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -153,7 +153,7 @@ class TowerStatus(StrEnum):
     UNKNOWN: str = "UNKNOWN"
 
 
-TOWER_WORKFLOW_STATUS: dict[str, str] = {
+TOWER_WORKFLOW_STATUS: dict[str, TrailblazerStatus] = {
     TowerStatus.ABORTED: TrailblazerStatus.FAILED,
     TowerStatus.CACHED: TrailblazerStatus.COMPLETED,
     TowerStatus.CANCELLED: TrailblazerStatus.CANCELLED,

--- a/trailblazer/dto/create_analysis_request.py
+++ b/trailblazer/dto/create_analysis_request.py
@@ -5,14 +5,14 @@ from trailblazer.constants import TrailblazerPriority, TrailblazerTypes, Workflo
 
 class CreateAnalysisRequest(BaseModel):
     case_id: str
-    email: str | None = None
     config_path: str
-    out_dir: str
-    order_id: int | None = None
-    priority: TrailblazerPriority
-    workflow: str | None = None
-    ticket: str | None = None
-    type: TrailblazerTypes
-    workflow_manager: WorkflowManager | None = None
-    tower_workflow_id: str | None = None
+    email: str | None = None
     is_hidden: bool | None = None
+    order_id: int | None = None
+    out_dir: str
+    priority: TrailblazerPriority
+    ticket: str | None = None
+    tower_workflow_id: str | None = None
+    type: TrailblazerTypes
+    workflow: str | None = None
+    workflow_manager: WorkflowManager | None = None

--- a/trailblazer/services/job_service/job_service.py
+++ b/trailblazer/services/job_service/job_service.py
@@ -61,11 +61,11 @@ class JobService:
         if analysis.status == TrailblazerStatus.CANCELLED:
             return TrailblazerStatus.CANCELLED
 
-        if not analysis.jobs:
-            raise NoJobsError(f"No jobs found for analysis {analysis_id}")
-
         if analysis.workflow_manager == WorkflowManager.TOWER:
             return self.tower_service.get_status(analysis_id)
+
+        if not analysis.jobs:
+            raise NoJobsError(f"No jobs found for analysis {analysis_id}")
 
         return get_status(analysis.jobs)
 

--- a/trailblazer/services/tower/tower_api_service.py
+++ b/trailblazer/services/tower/tower_api_service.py
@@ -31,7 +31,9 @@ class TowerAPIService:
     def get_status(self, analysis_id: int) -> TrailblazerStatus:
         analysis: Analysis = self.store.get_analysis_with_id(analysis_id)
         response = self.client.get_workflow(analysis.tower_workflow_id)
-        status = TOWER_WORKFLOW_STATUS.get(response.workflow.status, TrailblazerStatus.ERROR)
+        status: TrailblazerStatus = TOWER_WORKFLOW_STATUS.get(
+            response.workflow.status, TrailblazerStatus.ERROR
+        )
         if status == TrailblazerStatus.COMPLETED:
             return TrailblazerStatus.QC
         return status


### PR DESCRIPTION
## Description

### Added

- Two tests.

### Changed

- The status should now come from Tower. We are not checking if there are no jobs in analysis with Tower as manager. 

### Fixed

- Tower analysis should now not show up with the status `error` when they don't have jobs. 

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
