### PR TITLE
Export Tower workflow ID

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,6 +32,7 @@ def analysis(order_id_with_multiple_analyses) -> Analysis:
         started_at=datetime.datetime.now() - datetime.timedelta(weeks=1),
         status=TrailblazerStatus.PENDING,
         ticket_id="ticket_id",
+        tower_workflow_id="abc123",
         type=TYPES[0],
         workflow_manager=WorkflowManager.SLURM,
         is_visible=True,

--- a/tests/integration/endpoints/test_get_analysis.py
+++ b/tests/integration/endpoints/test_get_analysis.py
@@ -15,7 +15,7 @@ def test_get_existing_analysis(client: FlaskClient, analysis: Analysis):
 
     # THEN it should return the analysis
     assert response.json["id"] == analysis.id
-
+    assert response.json["tower_workflow_id"] == analysis.tower_workflow_id
 
 def test_get_non_existing_analysis(client: FlaskClient, non_existing_analysis_id: str):
     # GIVEN a non existing analysis id

--- a/tests/integration/endpoints/test_get_analysis.py
+++ b/tests/integration/endpoints/test_get_analysis.py
@@ -17,6 +17,7 @@ def test_get_existing_analysis(client: FlaskClient, analysis: Analysis):
     assert response.json["id"] == analysis.id
     assert response.json["tower_workflow_id"] == analysis.tower_workflow_id
 
+
 def test_get_non_existing_analysis(client: FlaskClient, non_existing_analysis_id: str):
     # GIVEN a non existing analysis id
 

--- a/trailblazer/dto/analysis_response.py
+++ b/trailblazer/dto/analysis_response.py
@@ -46,6 +46,7 @@ class AnalysisResponse(BaseModel):
     started_at: datetime | None = None
     status: TrailblazerStatus
     ticket_id: str | None = None
+    tower_workflow_id: str | None = None
     type: str | None = None
     upload_jobs: list[Job] = []
     uploaded_at: datetime | None = None

--- a/trailblazer/store/models.py
+++ b/trailblazer/store/models.py
@@ -150,6 +150,7 @@ class Analysis(Model):
             "started_at": self.started_at,
             "status": self.status,
             "ticket_id": self.ticket_id,
+            "tower_workflow_id": self.tower_workflow_id,
             "type": self.type,
             "uploaded_at": self.uploaded_at,
             "user_id": self.user_id,


### PR DESCRIPTION
## Description

To solve https://github.com/Clinical-Genomics/cigrid-ui/issues/863 we need the tower_workflow_id in the frontend.

### Added

-

### Changed

- The GET analysis response contains the tower_workflow_id.

### Fixed

-

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
