### PR TITLE
Exclude workflow feature in endpoint

### DIFF
--- a/tests/integration/endpoints/test_get_analyses.py
+++ b/tests/integration/endpoints/test_get_analyses.py
@@ -42,7 +42,7 @@ def test_get_analyses_filtered_by_single_status(client: FlaskClient, analyses: l
     # GIVEN analyses with different statuses
 
     # WHEN retrieving completed analyses
-    response = client.get("/api/v1/analyses?status[]=completed")
+    response = client.get(f"/api/v1/analyses?status[]=completed&pageSize={len(analyses)}")
 
     # THEN it gives a success response
     assert response.status_code == HTTPStatus.OK
@@ -181,4 +181,61 @@ def test_get_analyses_by_hold_delivery_none(client: FlaskClient, analyses: list[
     assert response.status_code == HTTPStatus.OK
 
     # THEN the same numebr of analyses is returned
+    assert len(response.json["analyses"]) == len(analyses)
+
+
+def test_get_analyses_by_excluding_workflow(client: FlaskClient, analyses: list[Analysis]):
+    # GIVEN analyses with different workflows
+    analyses[0].workflow = Workflow.RSYNC
+
+    # WHEN retrieving all analyses excluding the RSYNC workflow
+    response = client.get(
+        f"/api/v1/analyses?excludeWorkflow[]={Workflow.RSYNC}&pageSize={len(analyses)}"
+    )
+
+    # THEN it gives a success response
+    assert response.status_code == HTTPStatus.OK
+
+    # THEN no analysis with the RSYNC workflow should be returned
+    assert all(analysis["workflow"] != Workflow.RSYNC for analysis in response.json["analyses"])
+
+
+def test_get_analyses_by_excluding_multiple_workflows(
+    client: FlaskClient, analyses: list[Analysis]
+):
+    # GIVEN analyses with different workflows, two of which are RSYNC and MUTANT
+    analyses[0].workflow = Workflow.RSYNC
+    analyses[1].workflow = Workflow.MUTANT
+
+    # WHEN retrieving all analyses excluding the RSYNC and MUTANT workflows
+    response = client.get(
+        f"/api/v1/analyses?excludeWorkflow[]={Workflow.RSYNC}"
+        f"&excludeWorkflow[]={Workflow.MUTANT}&pageSize={len(analyses)}"
+    )
+
+    # THEN it gives a success response
+    assert response.status_code == HTTPStatus.OK
+
+    # THEN neither of the excluded analyses should be returned
+    assert len(response.json["analyses"]) == len(analyses) - 2
+
+    # THEN no analysis with the RSYNC or MUTANT workflow should be returned
+    assert all(
+        analysis["workflow"] not in (Workflow.RSYNC, Workflow.MUTANT)
+        for analysis in response.json["analyses"]
+    )
+
+
+def test_get_analyses_by_excluding_workflow_when_not_provided(
+    client: FlaskClient, analyses: list[Analysis]
+):
+    # GIVEN analyses with different workflows
+
+    # WHEN retrieving all analyses without excluding any workflow
+    response = client.get(f"/api/v1/analyses?pageSize={len(analyses)}")
+
+    # THEN it gives a success response
+    assert response.status_code == HTTPStatus.OK
+
+    # THEN all analyses are returned
     assert len(response.json["analyses"]) == len(analyses)

--- a/tests/store/filters/test_analysis_filters.py
+++ b/tests/store/filters/test_analysis_filters.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.orm import Query, Session
 
 from tests.mocks.store_mock import MockStore
+from trailblazer.constants import Workflow
 from trailblazer.store.database import get_session
 from trailblazer.store.filters.analyses_filters import (
     exclude_analysis_with_workflow,
@@ -376,6 +377,27 @@ def test_exclude_analysis_with_workflow(analysis_store: MockStore):
     # THEN no returned analysis should have the excluded workflow
     for analysis in analyses:
         assert analysis.workflow != existing_analysis.workflow
+
+
+def test_exclude_analysis_with_multiple_workflows(analysis_store: MockStore):
+    """Test excluding analyses with more than one workflow at once."""
+    # GIVEN a store containing analyses with, among others, RNAFUSION and MIP-DNA workflows
+    analyses: Query = analysis_store.get_query(table=Analysis)
+    assert analyses.filter(Analysis.workflow == Workflow.RNAFUSION).first()
+    assert analyses.filter(Analysis.workflow == Workflow.MIP_DNA).first()
+
+    # WHEN excluding analyses with either workflow
+    filtered_analyses: Query = exclude_analysis_with_workflow(
+        analyses=analysis_store.get_query(table=Analysis),
+        exclude_workflow=[Workflow.RNAFUSION, Workflow.MIP_DNA],
+    )
+
+    # THEN neither excluded workflow should be present in the results
+    for analysis in filtered_analyses:
+        assert analysis.workflow not in (Workflow.RNAFUSION, Workflow.MIP_DNA)
+
+    # THEN analyses with other workflows should still be returned
+    assert filtered_analyses.count() > 0
 
 
 def test_exclude_analysis_with_workflow_when_empty(analysis_store: MockStore):

--- a/tests/store/filters/test_analysis_filters.py
+++ b/tests/store/filters/test_analysis_filters.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Query, Session
 from tests.mocks.store_mock import MockStore
 from trailblazer.store.database import get_session
 from trailblazer.store.filters.analyses_filters import (
+    exclude_analysis_with_workflow,
     filter_analyses_by_before_started_at,
     filter_analyses_by_case_id,
     filter_analyses_by_comment,
@@ -356,3 +357,36 @@ def test_filter_analyses_by_statuses(analysis_store: MockStore):
 
     # THEN the analysis should match the original
     assert existing_analysis == analysis.first()
+
+
+def test_exclude_analysis_with_workflow(analysis_store: MockStore):
+    """Test excluding analyses with a given workflow."""
+    # GIVEN a store containing analyses
+    existing_analysis: Analysis = analysis_store.get_query(table=Analysis).first()
+
+    # WHEN excluding analyses with the existing analysis's workflow
+    analyses: Query = exclude_analysis_with_workflow(
+        analyses=analysis_store.get_query(table=Analysis),
+        exclude_workflow=[existing_analysis.workflow],
+    )
+
+    # THEN the analyses is a query
+    assert isinstance(analyses, Query)
+
+    # THEN no returned analysis should have the excluded workflow
+    for analysis in analyses:
+        assert analysis.workflow != existing_analysis.workflow
+
+
+def test_exclude_analysis_with_workflow_when_empty(analysis_store: MockStore):
+    """Test that no filtering is done when exclude_workflow is empty."""
+    # GIVEN a store containing analyses
+    analyses: Query = analysis_store.get_query(table=Analysis)
+
+    # WHEN excluding analyses without providing any workflow
+    filtered_analyses: Query = exclude_analysis_with_workflow(
+        analyses=analyses, exclude_workflow=None
+    )
+
+    # THEN no filtering should be done on the query
+    assert filtered_analyses == analyses

--- a/trailblazer/constants.py
+++ b/trailblazer/constants.py
@@ -37,12 +37,24 @@ class WorkflowManager(StrEnum):
 class Workflow(StrEnum):
     """Analysis workflow names."""
 
-    BALSAMIC: str = "BALSAMIC"
-    MIP_DNA: str = "MIP-DNA"
-    MIP_RNA: str = "MIP-RNA"
-    MUTANT: str = "MUTANT"
-    RSYNC: str = "RSYNC"
-    RAW_DATA: str = "RAW-DATA"
+    BALSAMIC = "BALSAMIC"
+    BALSAMIC_PON = "BALSAMIC-PON"
+    BALSAMIC_UMI = "BALSAMIC-UMI"
+    DEMULTIPLEX = "DEMULTIPLEX"
+    FLUFFY = "FLUFFY"
+    JASEN = "JASEN"
+    MICROSALT = "MICROSALT"
+    MIP_DNA = "MIP-DNA"
+    MIP_RNA = "MIP-RNA"
+    MUTANT = "MUTANT"
+    NALLO = "NALLO"
+    RAREDISEASE = "RAREDISEASE"
+    RAW_DATA = "RAW-DATA"
+    RNAFUSION = "RNAFUSION"
+    RSYNC = "RSYNC"
+    SPRING = "SPRING"
+    TAXPROFILER = "TAXPROFILER"
+    TOMTE = "TOMTE"
 
 
 class SlurmSqueueHeader(StrEnum):

--- a/trailblazer/dto/analyses_request.py
+++ b/trailblazer/dto/analyses_request.py
@@ -5,6 +5,7 @@ from trailblazer.constants import (
     TrailblazerPriority,
     TrailblazerStatus,
     TrailblazerTypes,
+    Workflow,
 )
 from trailblazer.dto.common import SortOrder
 
@@ -19,6 +20,7 @@ class AnalysisSortField(StrEnum):
 
 class AnalysesRequest(BaseModel):
     workflow: str = ""
+    exclude_workflow: list[Workflow] = Field(alias="excludeWorkflow", default=[])
     search: str | None = None
     page_size: int = Field(alias="pageSize", default=250)
     page: int = 1

--- a/trailblazer/store/crud/read.py
+++ b/trailblazer/store/crud/read.py
@@ -240,6 +240,7 @@ class ReadHandler(BaseHandler):
     def _filter_analyses(self, request: AnalysesRequest) -> Query:
         filters: list[AnalysisFilter] = [
             AnalysisFilter.BY_WORKFLOW,
+            AnalysisFilter.BY_EXCLUDE_WORKFLOW,
             AnalysisFilter.BY_HAS_COMMENT,
             AnalysisFilter.BY_ORDER_ID,
             AnalysisFilter.BY_PRIORITIES,
@@ -262,6 +263,7 @@ class ReadHandler(BaseHandler):
             statuses=request.status,
             types=request.type,
             case_id=request.case_id,
+            exclude_workflow=request.exclude_workflow,
             hold_delivery=request.hold_delivery,
             workflow=request.workflow,
             search_term=request.search,

--- a/trailblazer/store/filters/analyses_filters.py
+++ b/trailblazer/store/filters/analyses_filters.py
@@ -154,6 +154,15 @@ def filter_analyses_by_latest_per_case(analyses: Query, **kwargs) -> Query:
     return latest_analysis_per_case
 
 
+def exclude_analysis_with_workflow(
+    analyses: Query, exclude_workflow: list[Workflow] | None, **kwargs
+) -> Query:
+    """Exclude analyses with any of the given workflows."""
+    if not exclude_workflow:
+        return analyses
+    return analyses.filter(Analysis.workflow.notin_(exclude_workflow))
+
+
 def sort_analyses(
     analyses: Query, sort_field: AnalysisSortField, sort_order: SortOrder, **kwargs
 ) -> Query:
@@ -192,6 +201,7 @@ class AnalysisFilter(Enum):
     BY_COMPLETED: Callable = get_completed_analyses
     BY_DELIVERED: Callable = filter_analyses_by_delivered
     BY_ENTRY_ID: Callable = filter_analyses_by_entry_id
+    BY_EXCLUDE_WORKFLOW: Callable = exclude_analysis_with_workflow
     BY_HAS_COMMENT: Callable = filter_analyses_by_has_comment
     BY_HOLD_DELIVERY: Callable = filter_analyses_by_hold_delivery
     BY_IS_VISIBLE: Callable = filter_analyses_by_is_visible
@@ -217,6 +227,7 @@ def apply_analysis_filter(
     case_id: str | None = None,
     comment: str | None = None,
     delivered: bool | None = None,
+    exclude_workflow: list[Workflow] | None = None,
     has_comment: bool | None = None,
     hold_delivery: bool | None = None,
     order_id: int | None = None,
@@ -243,6 +254,7 @@ def apply_analysis_filter(
             case_id=case_id,
             comment=comment,
             delivered=delivered,
+            exclude_workflow=exclude_workflow,
             has_comment=has_comment,
             hold_delivery=hold_delivery,
             order_id=order_id,


### PR DESCRIPTION
## Description

Allows exclusion of workflow in the request body in the analyses endpoint.
Like this:
```
api/v1/analyses?excludeWorkflow[]=RSYNC
```

### Added

- Exclude workflow filter.


### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
