### PR TITLE
Remove default page size

### DIFF
--- a/tests/integration/endpoints/test_get_analyses.py
+++ b/tests/integration/endpoints/test_get_analyses.py
@@ -190,7 +190,7 @@ def test_get_analyses_by_excluding_workflow(client: FlaskClient, analyses: list[
 
     # WHEN retrieving all analyses excluding the RSYNC workflow
     response = client.get(
-        f"/api/v1/analyses?excludeWorkflow[]={Workflow.RSYNC}&pageSize={len(analyses)}"
+        f"/api/v1/analyses?excludeWorkflow[]={Workflow.RSYNC}"
     )
 
     # THEN it gives a success response
@@ -201,7 +201,7 @@ def test_get_analyses_by_excluding_workflow(client: FlaskClient, analyses: list[
 
 
 def test_get_analyses_by_excluding_multiple_workflows(
-    client: FlaskClient, analyses: list[Analysis]
+client: FlaskClient, analyses: list[Analysis]
 ):
     # GIVEN analyses with different workflows, two of which are RSYNC and MUTANT
     analyses[0].workflow = Workflow.RSYNC
@@ -210,7 +210,7 @@ def test_get_analyses_by_excluding_multiple_workflows(
     # WHEN retrieving all analyses excluding the RSYNC and MUTANT workflows
     response = client.get(
         f"/api/v1/analyses?excludeWorkflow[]={Workflow.RSYNC}"
-        f"&excludeWorkflow[]={Workflow.MUTANT}&pageSize={len(analyses)}"
+        f"&excludeWorkflow[]={Workflow.MUTANT}"
     )
 
     # THEN it gives a success response
@@ -227,15 +227,32 @@ def test_get_analyses_by_excluding_multiple_workflows(
 
 
 def test_get_analyses_by_excluding_workflow_when_not_provided(
-    client: FlaskClient, analyses: list[Analysis]
+client: FlaskClient, analyses: list[Analysis]
 ):
     # GIVEN analyses with different workflows
 
     # WHEN retrieving all analyses without excluding any workflow
-    response = client.get(f"/api/v1/analyses?pageSize={len(analyses)}")
+    response = client.get("/api/v1/analyses?")
 
     # THEN it gives a success response
     assert response.status_code == HTTPStatus.OK
 
     # THEN all analyses are returned
     assert len(response.json["analyses"]) == len(analyses)
+
+
+def test_get_analyses_pagination(client: FlaskClient, analyses: list[Analysis]):
+    # GIVEN list of analyses
+    first_analysis = analyses[0]
+    first_analysis.id = 1337
+
+
+    # WHEN retrieving analyses with page size one
+    response = client.get("/api/v1/analyses?pageSize=1&page=1&sortOrder=asc")
+
+    # THEN there should only be one analysis
+    assert len(response.json["analyses"]) == 1
+
+    # THEN it should be the first analysis
+    assert response.json["analyses"][0]["id"] == first_analysis.id
+

--- a/tests/integration/endpoints/test_get_analyses.py
+++ b/tests/integration/endpoints/test_get_analyses.py
@@ -189,9 +189,7 @@ def test_get_analyses_by_excluding_workflow(client: FlaskClient, analyses: list[
     analyses[0].workflow = Workflow.RSYNC
 
     # WHEN retrieving all analyses excluding the RSYNC workflow
-    response = client.get(
-        f"/api/v1/analyses?excludeWorkflow[]={Workflow.RSYNC}"
-    )
+    response = client.get(f"/api/v1/analyses?excludeWorkflow[]={Workflow.RSYNC}")
 
     # THEN it gives a success response
     assert response.status_code == HTTPStatus.OK
@@ -201,7 +199,7 @@ def test_get_analyses_by_excluding_workflow(client: FlaskClient, analyses: list[
 
 
 def test_get_analyses_by_excluding_multiple_workflows(
-client: FlaskClient, analyses: list[Analysis]
+    client: FlaskClient, analyses: list[Analysis]
 ):
     # GIVEN analyses with different workflows, two of which are RSYNC and MUTANT
     analyses[0].workflow = Workflow.RSYNC
@@ -227,7 +225,7 @@ client: FlaskClient, analyses: list[Analysis]
 
 
 def test_get_analyses_by_excluding_workflow_when_not_provided(
-client: FlaskClient, analyses: list[Analysis]
+    client: FlaskClient, analyses: list[Analysis]
 ):
     # GIVEN analyses with different workflows
 
@@ -246,7 +244,6 @@ def test_get_analyses_pagination(client: FlaskClient, analyses: list[Analysis]):
     first_analysis = analyses[0]
     first_analysis.id = 1337
 
-
     # WHEN retrieving analyses with page size one
     response = client.get("/api/v1/analyses?pageSize=1&page=1&sortOrder=asc")
 
@@ -255,4 +252,3 @@ def test_get_analyses_pagination(client: FlaskClient, analyses: list[Analysis]):
 
     # THEN it should be the first analysis
     assert response.json["analyses"][0]["id"] == first_analysis.id
-

--- a/trailblazer/dto/analyses_request.py
+++ b/trailblazer/dto/analyses_request.py
@@ -22,7 +22,7 @@ class AnalysesRequest(BaseModel):
     workflow: str = ""
     exclude_workflow: list[Workflow] = Field(alias="excludeWorkflow", default=[])
     search: str | None = None
-    page_size: int = Field(alias="pageSize", default=250)
+    page_size: int | None = Field(alias="pageSize", default=None)
     page: int = 1
     sort_field: AnalysisSortField = Field(alias="sortField", default=AnalysisSortField.STARTED_AT)
     sort_order: SortOrder = Field(alias="sortOrder", default=SortOrder.DESC)


### PR DESCRIPTION
## Description
The analyses GET endpoint had a default page size (250), which could mislead callers into thinking a capped response was the full result set. To remove that confusion, the default `pageSize` has been removed — if `pageSize` is omitted, all matching analyses are now returned instead of being capped at 250.

### Changed

- Removed default page size in get analyses endpoint; omitting `pageSize` now returns all matching analyses instead of the first 250.

### How to prepare for test
- [ ] ssh to hasta (depending on type of change)
- [ ] activate stage: `us`
- [ ] request trailblazer-stage on hasta: `paxa`
- [ ] install on stage:
    ```Shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_trailblazer -t trailblazer -b [THIS-BRANCH-NAME] -a
    ```
- [ ] ssh to clinical-db (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/clinical-db.scilifelab.se/update-trailblazer-ui-stage.sh remove-default-page-size`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
